### PR TITLE
feat(core): add dist build output and exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,24 @@
   "bin": {
     "echo-pdf": "./bin/echo-pdf.js"
   },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "files": [
     "bin",
-    "src",
+    "dist",
     "scripts",
     "README.md",
     "wrangler.toml",
     "echo-pdf.config.json"
   ],
   "scripts": {
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "check:runtime": "bash ./scripts/check-runtime.sh",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
@@ -26,7 +35,7 @@
     "test:integration": "npm run check:runtime && vitest run tests/integration",
     "test": "npm run test:unit && npm run test:integration",
     "smoke": "bash ./scripts/smoke.sh",
-    "prepublishOnly": "npm run typecheck && npm run test"
+    "prepublishOnly": "npm run build && npm run typecheck && npm run test"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmit": false
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary\n- add TypeScript build config emitting JS + d.ts to dist/\n- add package exports/main/types pointing to dist artifacts\n- update prepublishOnly to run build + typecheck + test\n\n## Validation\n- npm run build\n- npm run typecheck\n- npm test\n- npm pack\n\nCloses #5