### PR TITLE
feat(core): expose stable public tool API

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,3 +2,73 @@ export { callTool, listToolSchemas } from "../tool-registry"
 export type { ToolRuntimeContext } from "../tool-registry"
 export type { ToolSchema } from "../pdf-types"
 export type { Env, FileStore, JsonObject } from "../types"
+import { callTool } from "../tool-registry"
+import type { JsonObject } from "../types"
+import type { ReturnMode } from "../types"
+
+export interface PdfExtractPagesArgs {
+  readonly fileId?: string
+  readonly url?: string
+  readonly base64?: string
+  readonly filename?: string
+  readonly pages: ReadonlyArray<number>
+  readonly renderScale?: number
+  readonly returnMode?: ReturnMode
+}
+
+export interface PdfOcrPagesArgs {
+  readonly fileId?: string
+  readonly url?: string
+  readonly base64?: string
+  readonly filename?: string
+  readonly pages: ReadonlyArray<number>
+  readonly renderScale?: number
+  readonly provider?: string
+  readonly model?: string
+  readonly prompt?: string
+}
+
+export interface PdfTablesToLatexArgs {
+  readonly fileId?: string
+  readonly url?: string
+  readonly base64?: string
+  readonly filename?: string
+  readonly pages: ReadonlyArray<number>
+  readonly renderScale?: number
+  readonly provider?: string
+  readonly model?: string
+  readonly prompt?: string
+}
+
+export interface FileOpsArgs {
+  readonly op: "list" | "read" | "delete" | "put"
+  readonly fileId?: string
+  readonly includeBase64?: boolean
+  readonly text?: string
+  readonly filename?: string
+  readonly mimeType?: string
+  readonly base64?: string
+  readonly returnMode?: ReturnMode
+}
+
+const asJsonObject = (value: unknown): JsonObject => value as JsonObject
+
+export const pdf_extract_pages = async (
+  args: PdfExtractPagesArgs,
+  ctx: import("../tool-registry").ToolRuntimeContext
+): Promise<unknown> => callTool("pdf_extract_pages", asJsonObject(args), ctx)
+
+export const pdf_ocr_pages = async (
+  args: PdfOcrPagesArgs,
+  ctx: import("../tool-registry").ToolRuntimeContext
+): Promise<unknown> => callTool("pdf_ocr_pages", asJsonObject(args), ctx)
+
+export const pdf_tables_to_latex = async (
+  args: PdfTablesToLatexArgs,
+  ctx: import("../tool-registry").ToolRuntimeContext
+): Promise<unknown> => callTool("pdf_tables_to_latex", asJsonObject(args), ctx)
+
+export const file_ops = async (
+  args: FileOpsArgs,
+  ctx: import("../tool-registry").ToolRuntimeContext
+): Promise<unknown> => callTool("file_ops", asJsonObject(args), ctx)


### PR DESCRIPTION
## Summary\n- expose typed tool wrapper functions from core API:\n  - pdf_extract_pages\n  - pdf_ocr_pages\n  - pdf_tables_to_latex\n  - file_ops\n- keep wrappers delegating to existing tool-registry callTool implementation\n- keep Worker router and CLI behavior unchanged\n\n## Validation\n- npm run build\n- npm run typecheck\n- npm test\n- npm pack\n\nCloses #6