### PR TITLE
ci: add codex review/fix webhook workflows

### DIFF
--- a/.github/workflows/codex-fix.yml
+++ b/.github/workflows/codex-fix.yml
@@ -1,0 +1,51 @@
+name: codex-fix
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: codex-fix-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  notify:
+    if: github.event.label.name == 'codex-fix'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if webhook not configured
+        id: gate
+        run: |
+          if [ -z "${{ secrets.CODEX_WEBHOOK_URL }}" ]; then
+            echo "CODEX_WEBHOOK_URL not set; skipping."
+            exit 0
+          fi
+
+      - name: Notify Codex fixer webhook
+        env:
+          CODEX_WEBHOOK_URL: ${{ secrets.CODEX_WEBHOOK_URL }}
+          CODEX_WEBHOOK_TOKEN: ${{ secrets.CODEX_WEBHOOK_TOKEN }}
+        run: |
+          payload="$(jq -n \
+            --arg mode "fix" \
+            --arg event "${GITHUB_EVENT_NAME}" \
+            --arg repo "${GITHUB_REPOSITORY}" \
+            --arg prNumber "${{ github.event.pull_request.number }}" \
+            --arg prUrl "${{ github.event.pull_request.html_url }}" \
+            --arg sha "${{ github.event.pull_request.head.sha }}" \
+            '{mode:$mode,event:$event,repo:$repo,prNumber:($prNumber|tonumber),prUrl:$prUrl,sha:$sha}')"
+
+          auth_header=""
+          if [ -n "${CODEX_WEBHOOK_TOKEN}" ]; then
+            auth_header="Authorization: Bearer ${CODEX_WEBHOOK_TOKEN}"
+          fi
+
+          curl -fsS -X POST "${CODEX_WEBHOOK_URL}" \
+            -H "Content-Type: application/json" \
+            ${auth_header:+-H "$auth_header"} \
+            -d "${payload}"
+

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,92 @@
+name: codex-review
+
+on:
+  pull_request:
+    types: [ready_for_review]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip if webhook not configured
+        id: gate
+        run: |
+          if [ -z "${{ secrets.CODEX_WEBHOOK_URL }}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "CODEX_WEBHOOK_URL not set; skipping."
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Determine PR context
+        if: steps.gate.outputs.configured == 'true'
+        id: ctx
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            let pr = null;
+
+            if (eventName === "pull_request") {
+              pr = context.payload.pull_request;
+            } else if (eventName === "check_suite") {
+              // check_suite payload includes associated pull requests (if any)
+              const prs = context.payload.check_suite?.pull_requests ?? [];
+              pr = prs.length > 0 ? prs[0] : null;
+            }
+
+            // If checks completed but not for a PR, do nothing.
+            if (!pr) {
+              core.setOutput("skip", "true");
+              return;
+            }
+
+            // Only trigger "final review" when check_suite is successful.
+            if (eventName === "check_suite") {
+              const conclusion = context.payload.check_suite?.conclusion ?? "";
+              if (conclusion !== "success") {
+                core.setOutput("skip", "true");
+                return;
+              }
+            }
+
+            core.setOutput("skip", "false");
+            core.setOutput("pr_number", String(pr.number));
+            core.setOutput("pr_url", pr.html_url ?? "");
+            core.setOutput("head_sha", pr.head?.sha ?? "");
+
+      - name: Notify Codex reviewer webhook
+        if: steps.gate.outputs.configured == 'true' && steps.ctx.outputs.skip == 'false'
+        env:
+          CODEX_WEBHOOK_URL: ${{ secrets.CODEX_WEBHOOK_URL }}
+          CODEX_WEBHOOK_TOKEN: ${{ secrets.CODEX_WEBHOOK_TOKEN }}
+        run: |
+          payload="$(jq -n \
+            --arg mode "review" \
+            --arg event "${GITHUB_EVENT_NAME}" \
+            --arg repo "${GITHUB_REPOSITORY}" \
+            --arg prNumber "${{ steps.ctx.outputs.pr_number }}" \
+            --arg prUrl "${{ steps.ctx.outputs.pr_url }}" \
+            --arg sha "${{ steps.ctx.outputs.head_sha }}" \
+            '{mode:$mode,event:$event,repo:$repo,prNumber:($prNumber|tonumber),prUrl:$prUrl,sha:$sha}')"
+
+          auth_header=""
+          if [ -n "${CODEX_WEBHOOK_TOKEN}" ]; then
+            auth_header="Authorization: Bearer ${CODEX_WEBHOOK_TOKEN}"
+          fi
+
+          curl -fsS -X POST "${CODEX_WEBHOOK_URL}" \
+            -H "Content-Type: application/json" \
+            ${auth_header:+-H "$auth_header"} \
+            -d "${payload}"
+


### PR DESCRIPTION
Adds two GitHub Actions workflows:

- codex-review.yml
  - Triggers on PR `ready_for_review`
  - Also triggers on successful `check_suite` completion (only when associated with a PR)
  - Posts a JSON payload to `secrets.CODEX_WEBHOOK_URL` (optional bearer token `secrets.CODEX_WEBHOOK_TOKEN`)

- codex-fix.yml
  - Triggers when a PR is labeled `codex-fix`
  - Posts a JSON payload to the same webhook

If the webhook secret is not configured, workflows no-op successfully.
