### PR TITLE
test(core): add no-mock direct import integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "deploy": "wrangler deploy",
     "typecheck": "npm run check:runtime && tsc --noEmit",
     "test:unit": "npm run check:runtime && vitest run tests/unit",
-    "test:integration": "npm run check:runtime && vitest run tests/integration",
+    "test:integration": "npm run check:runtime && npm run build && vitest run tests/integration",
     "test": "npm run test:unit && npm run test:integration",
     "smoke": "bash ./scripts/smoke.sh",
     "prepublishOnly": "npm run build && npm run typecheck && npm run test"

--- a/src/pdfium-engine.ts
+++ b/src/pdfium-engine.ts
@@ -1,15 +1,16 @@
 import { init } from "@embedpdf/pdfium"
-import { encode as encodePng } from "@cf-wasm/png/workerd"
+import { encode as encodePng } from "@cf-wasm/png"
 import type { WrappedPdfiumModule } from "@embedpdf/pdfium"
 import type { EchoPdfConfig } from "./pdf-types"
 import { toDataUrl } from "./file-utils"
-import compiledPdfiumModule from "@embedpdf/pdfium/dist/pdfium.wasm"
 
 let moduleInstance: WrappedPdfiumModule | null = null
 let libraryInitialized = false
 
 const toUint8 = (value: ArrayBuffer): Uint8Array => new Uint8Array(value)
 const textDecoder = new TextDecoder()
+const isWorkerdRuntime = (): boolean =>
+  typeof (globalThis as { WebSocketPair?: unknown }).WebSocketPair === "function"
 
 const ensureWasmFunctionShim = (): void => {
   const wasmApi = WebAssembly as unknown as {
@@ -25,19 +26,23 @@ const ensureWasmFunctionShim = (): void => {
 const ensurePdfium = async (config: EchoPdfConfig): Promise<WrappedPdfiumModule> => {
   ensureWasmFunctionShim()
   if (!moduleInstance) {
-    const maybeModule = compiledPdfiumModule as unknown
-    if (maybeModule instanceof WebAssembly.Module) {
-      moduleInstance = await init({
-        instantiateWasm: (
-          imports: WebAssembly.Imports,
-          successCallback: (instance: WebAssembly.Instance, module: WebAssembly.Module) => void
-        ): WebAssembly.Exports => {
-          const instance = new WebAssembly.Instance(maybeModule, imports)
-          successCallback(instance, maybeModule)
-          return instance.exports
-        },
-      })
-    } else {
+    if (isWorkerdRuntime()) {
+      const wasmModuleImport = await import("@embedpdf/pdfium/pdfium.wasm")
+      const maybeModule = (wasmModuleImport as { default?: unknown }).default ?? wasmModuleImport
+      if (maybeModule instanceof WebAssembly.Module) {
+        moduleInstance = await init({
+          instantiateWasm: (
+            imports: WebAssembly.Imports,
+            successCallback: (instance: WebAssembly.Instance, module: WebAssembly.Module) => void
+          ): WebAssembly.Exports => {
+            const instance = new WebAssembly.Instance(maybeModule, imports)
+            successCallback(instance, maybeModule)
+            return instance.exports
+          },
+        })
+      }
+    }
+    if (!moduleInstance) {
       const wasmBinary = await fetch(config.pdfium.wasmUrl).then((res) => res.arrayBuffer())
       moduleInstance = await init({ wasmBinary })
     }

--- a/tests/integration/core-import.integration.test.ts
+++ b/tests/integration/core-import.integration.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import configJson from "../../echo-pdf.config.json"
+import type { EchoPdfConfig } from "../../src/pdf-types"
+import type { Env, FileStore, StoredFileMeta, StoredFileRecord } from "../../src/types"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, "../..")
+const fixturePdf = path.join(rootDir, "fixtures", "smoke.pdf")
+
+class InMemoryFileStore implements FileStore {
+  private readonly records = new Map<string, StoredFileRecord>()
+  private seq = 0
+
+  async put(input: {
+    readonly filename: string
+    readonly mimeType: string
+    readonly bytes: Uint8Array
+  }): Promise<StoredFileMeta> {
+    this.seq += 1
+    const id = `mem-${this.seq}`
+    const record: StoredFileRecord = {
+      id,
+      filename: input.filename,
+      mimeType: input.mimeType,
+      sizeBytes: input.bytes.byteLength,
+      createdAt: new Date().toISOString(),
+      bytes: input.bytes,
+    }
+    this.records.set(id, record)
+    return record
+  }
+
+  async get(fileId: string): Promise<StoredFileRecord | null> {
+    return this.records.get(fileId) ?? null
+  }
+
+  async list(): Promise<ReadonlyArray<StoredFileMeta>> {
+    return Array.from(this.records.values())
+  }
+
+  async delete(fileId: string): Promise<boolean> {
+    return this.records.delete(fileId)
+  }
+}
+
+describe("core import integration", () => {
+  it("imports package exports and runs pdf_extract_pages without mocks", async () => {
+    const core = await import("@echofiles/echo-pdf")
+    const pdfExtractPages = core.pdf_extract_pages as (
+      args: { fileId: string; pages: number[]; returnMode: "inline" },
+      ctx: {
+        config: EchoPdfConfig
+        env: Env
+        fileStore: FileStore
+      }
+    ) => Promise<unknown>
+
+    expect(typeof pdfExtractPages).toBe("function")
+
+    const fileStore = new InMemoryFileStore()
+    const bytes = new Uint8Array(await readFile(fixturePdf))
+    const stored = await fileStore.put({
+      filename: "smoke.pdf",
+      mimeType: "application/pdf",
+      bytes,
+    })
+
+    const result = await pdfExtractPages(
+      { fileId: stored.id, pages: [1], returnMode: "inline" },
+      {
+        config: configJson as EchoPdfConfig,
+        env: {} as Env,
+        fileStore,
+      }
+    ) as {
+      fileId: string
+      images: Array<{ data?: string; mimeType?: string }>
+    }
+
+    expect(result.fileId).toBe(stored.id)
+    expect(result.images.length).toBe(1)
+    expect(result.images[0]?.mimeType).toBe("image/png")
+    expect(result.images[0]?.data?.startsWith("data:image/png;base64,")).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary\n- add integration test that imports package exports and executes pdf_extract_pages with an in-memory FileStore\n- run integration tests against built dist output to validate consumer-style import path\n- improve wasm loading compatibility for direct import across Node + workerd runtimes\n\n## Validation\n- npm run build\n- npm run typecheck\n- npm test\n- npm pack\n\nCloses #3