### PR TITLE
fix: NodeNext type compatibility for /worker and core

### DIFF
--- a/src/file-store-do.ts
+++ b/src/file-store-do.ts
@@ -1,6 +1,12 @@
 import { fromBase64, toBase64 } from "./file-utils.js"
 import type { StoragePolicy } from "./pdf-types.js"
-import type { StoredFileMeta, StoredFileRecord } from "./types.js"
+import type {
+  DurableObjectNamespace,
+  DurableObjectState,
+  DurableObjectStub,
+  StoredFileMeta,
+  StoredFileRecord,
+} from "./types.js"
 
 interface StoredValue {
   readonly id: string

--- a/src/r2-file-store.ts
+++ b/src/r2-file-store.ts
@@ -1,5 +1,5 @@
 import type { StoragePolicy } from "./pdf-types.js"
-import type { FileStore, StoredFileMeta, StoredFileRecord } from "./types.js"
+import type { FileStore, R2Bucket, StoredFileMeta, StoredFileRecord } from "./types.js"
 
 const PREFIX = "file/"
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,12 +8,70 @@ export interface JsonObject {
 export type ProviderType = "openai" | "openrouter" | "vercel-ai-gateway"
 export type ReturnMode = "inline" | "file_id" | "url"
 
+export interface Fetcher {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>
+}
+
+export interface DurableObjectStub {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>
+}
+
+export interface DurableObjectId {}
+
+export interface DurableObjectNamespace {
+  idFromName(name: string): DurableObjectId
+  get(id: DurableObjectId): DurableObjectStub
+}
+
+export interface DurableObjectStorage {
+  get<T>(key: string): Promise<T | undefined>
+  put<T>(key: string, value: T): Promise<void>
+  list<T>(options?: { prefix?: string }): Promise<Map<string, T>>
+  delete(key: string): Promise<boolean>
+}
+
+export interface DurableObjectState {
+  storage: DurableObjectStorage
+}
+
+export interface R2ObjectBody {
+  key: string
+  size: number
+  uploaded: Date
+  httpMetadata?: { contentType?: string }
+  customMetadata?: Record<string, string>
+  arrayBuffer(): Promise<ArrayBuffer>
+}
+
+export interface R2Bucket {
+  put(
+    key: string,
+    value: ArrayBuffer | ArrayBufferView,
+    options?: {
+      httpMetadata?: { contentType?: string }
+      customMetadata?: Record<string, string>
+    }
+  ): Promise<unknown>
+  get(key: string): Promise<R2ObjectBody | null>
+  delete(key: string | string[]): Promise<void>
+  list(options?: { prefix?: string; limit?: number; cursor?: string }): Promise<{
+    objects: R2ObjectBody[]
+    truncated: boolean
+    cursor?: string
+  }>
+}
+
 export interface Env {
   readonly ECHO_PDF_CONFIG_JSON?: string
   readonly ASSETS?: Fetcher
   readonly FILE_STORE_BUCKET?: R2Bucket
   readonly FILE_STORE_DO?: DurableObjectNamespace
   readonly [key: string]: string | Fetcher | DurableObjectNamespace | R2Bucket | undefined
+}
+
+export interface WorkerExecutionContext {
+  waitUntil(promise: Promise<unknown>): void
+  passThroughOnException?(): void
 }
 
 export interface StoredFileMeta {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,7 +9,7 @@ import { listProviderModels } from "./provider-client.js"
 import { buildToolOutputEnvelope } from "./response-schema.js"
 import { callTool, listToolSchemas } from "./tool-registry.js"
 import type { AgentTraceEvent, PdfOperationRequest } from "./pdf-types.js"
-import type { Env, JsonObject } from "./types.js"
+import type { Env, JsonObject, WorkerExecutionContext } from "./types.js"
 
 const json = (data: unknown, status = 200): Response =>
   new Response(JSON.stringify(data), {
@@ -127,7 +127,7 @@ const operationArgsFromRequest = (request: PdfOperationRequest): JsonObject => {
 }
 
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: WorkerExecutionContext): Promise<Response> {
     const url = new URL(request.url)
     const config = loadEchoPdfConfig(env)
     const runtimeStore = getRuntimeFileStore(env, config)

--- a/tests/integration/ts-nodenext-consumer.integration.test.ts
+++ b/tests/integration/ts-nodenext-consumer.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, "../..")
+
+const run = async (cmd: string, args: string[], cwd: string): Promise<string> => {
+  const { stdout } = await execFileAsync(cmd, args, { cwd, env: process.env })
+  return stdout
+}
+
+describe("ts nodenext consumer smoke", () => {
+  it("typechecks package root/core/worker imports in a fresh consumer", async () => {
+    const packJson = await run("npm", ["pack", "--json"], rootDir)
+    const parsed = JSON.parse(packJson) as Array<{ filename?: string }>
+    const filename = parsed[0]?.filename
+    expect(typeof filename).toBe("string")
+    const tgzPath = path.join(rootDir, String(filename))
+
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-ts-"))
+    try {
+      await run("npm", ["init", "-y"], tempDir)
+      await run("npm", ["i", tgzPath], tempDir)
+      await run("npm", ["i", "-D", "typescript@5"], tempDir)
+
+      await writeFile(path.join(tempDir, "index.ts"), [
+        "import * as pkg from '@echofiles/echo-pdf'",
+        "import * as core from '@echofiles/echo-pdf/core'",
+        "import worker from '@echofiles/echo-pdf/worker'",
+        "pkg.listToolSchemas()",
+        "core.listToolSchemas()",
+        "worker",
+        "",
+      ].join("\n"))
+      await writeFile(path.join(tempDir, "tsconfig.json"), JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          strict: true,
+          noEmit: true,
+        },
+        include: ["index.ts"],
+      }, null, 2))
+
+      await run("npx", ["tsc", "--noEmit"], tempDir)
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- remove reliance on ambient Cloudflare global types from published declarations
- introduce local runtime type interfaces for worker/env/storage bindings
- use WorkerExecutionContext in worker entry declaration instead of ambient ExecutionContext
- add integration test that validates fresh NodeNext TS consumer can import:
  - @echofiles/echo-pdf
  - @echofiles/echo-pdf/core
  - @echofiles/echo-pdf/worker
  and pass tsc --noEmit

## Validation
- npm run typecheck
- npm run test:integration

Closes #17