### PR TITLE
docs: add development constraints for local-first refactor

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,64 +1,71 @@
 # Development Notes
 
-## Runtime requirement
+## Current Direction
 
-- Node.js >= 20
-- `npm run check:runtime`
+`echo-pdf` is now a local-first document component core.
 
-## Local development
+Priority in this phase:
 
-```bash
-npm install
-npm run dev
-```
+- local CLI
+- local library/client API
+- local artifacts/workspace
+- document context primitives such as `get_document`, `get_document_structure`, and `get_page_content`
 
-## Test commands
+Deferred in this phase:
 
-```bash
-npm run typecheck
-npm run test:unit
-npm run test:integration
-npm run test
-npm run smoke
-```
+- MCP expansion
+- hosted SaaS / platform work
+- domain-specific extraction logic
 
-Notes:
+If the current internal structure becomes more expensive than rebuilding, a greenfield rebuild inside this repo is allowed. Preserve the repo identity and product boundary.
 
-- `smoke` reuses `test:integration` (compat alias)
-- Integration tests read `../.env.local` automatically
-- Integration/Smoke sample PDF priority:
-  1. `TESTCASE_DIR` (default `../testcase/eda`) first PDF
-  2. `fixtures/smoke.pdf`
+## Runtime Boundaries
 
-Useful env vars:
+- Node.js `>= 20` is the baseline runtime. Do not treat older local Node versions as a repo bug.
+- Do not mix Node-only code into Worker-only paths.
+- If Node APIs are introduced, keep them in Node-specific modules or entrypoints.
+- Do not solve boundary problems by injecting Node globals or Node types into the whole project.
 
-- `SMOKE_BASE_URL` (test deployed service)
-- `SMOKE_REQUIRE_LLM=1` (fail when no LLM key)
-- `SMOKE_LLM_PROVIDER=openrouter|openai|vercel_gateway`
-- `SMOKE_LLM_MODEL=<model-id>`
-- `TESTCASE_DIR=<path>`
+## Validation Order
 
-## Deploy
+Always classify failures before changing code:
 
-```bash
-npm run deploy
-```
+1. Static/build validation
+   - `npm run check:runtime`
+   - `npm run typecheck`
+2. Unit tests
+   - `npm run test:unit`
+3. Integration tests
+   - `npm run test:integration`
+4. Full verification
+   - `npm test`
 
-Required GitHub Actions secrets:
+Rules:
 
-- `CLOUDFLARE_API_TOKEN`
-- `CLOUDFLARE_ACCOUNT_ID`
+- Environment failures are not product conclusions.
+- `bun` may help local diagnosis, but the repo is judged by the declared Node runtime and CI path.
+- Port binding, system permissions, and local runtime mismatch must be reported as infra blockers, not hidden by code changes.
 
-Optional for real LLM integration checks:
+## Testing Policy
 
-- `OPENAI_API_KEY`
-- `OPENROUTER_KEY` / `OPENROUTER_API_KEY`
-- `VERCEL_AI_GATEWAY_API_KEY` / `VERCEL_AI_GATEWAY_KEY`
+- No mocks unless explicitly approved.
+- Integration tests should be env-gated when they require real providers or local services.
+- Do not weaken product scope to make tests easier.
+- Do not merge static, unit, and integration failures into one vague "test failed" statement. Report the layer.
 
-## Publish
+## Local-First Development
 
-```bash
-npm whoami
-npm pack --dry-run
-npm publish --access public
-```
+- Prefer explicit local workflows over hosted assumptions.
+- Local artifacts should be inspectable and reusable.
+- Repeated local runs should reuse prior artifacts/workspace when reasonable.
+
+## Pull Request Expectations
+
+Every PR should state:
+
+- which runtime boundary it touches: Node, Worker, or shared
+- which validation layers were run
+- which checks were blocked by infra, if any
+- whether the change is a targeted fix or part of a greenfield rebuild
+
+Keep PRs small and mergeable. Do not combine architecture migration, new product surface, and broad test rewrites unless the issue explicitly allows a rebuild.


### PR DESCRIPTION
Adds concrete runtime, validation, testing, and PR constraints for the local-first echo-pdf direction.