### PR TITLE
feat: add local-first document core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 *.log
 .DS_Store
 /fixtures/output/
+*.tgz
+_deepreview/
+_prfix/

--- a/README.md
+++ b/README.md
@@ -1,85 +1,88 @@
 # echo-pdf
 
-`echo-pdf` 是一个部署在 Cloudflare Workers 的 PDF Agent，支持：
+`echo-pdf` 当前阶段定位为本地优先的 document component core，支持：
 
 - 页面提取：把 PDF 指定页渲染为图片
 - OCR：识别页面文本
 - 表格识别：提取表格并输出 LaTeX `tabular`
-- MCP 服务：可直接挂到 Claude Desktop / Cursor / Cline / Windsurf 等客户端
+- 页级文档索引：生成本地可复用的 document / page artifacts
 
-支持三种使用方式：
+当前阶段优先：
 
-- MCP（推荐）
-- CLI
-- HTTP API
+- 本地 CLI
+- 本地 library/client API
+- 本地 workspace artifacts
 
-## Use echo-pdf as a component
+当前阶段非重点：
 
-推荐把 `echo-pdf` 作为一个独立组件服务接入（MCP-first，HTTP fallback），下游系统（如 echo-datasheet）只通过 URL 调用，不直接依赖实现代码。
+- MCP 扩展
+- Hosted SaaS / multi-tenant 平台能力
 
-### Downstream config
+## Local-first workflow
 
-下游至少配置以下变量：
-
-```bash
-export ECHO_PDF_BASE_URL="http://127.0.0.1:8787"
-export ECHO_PDF_MCP_URL="${ECHO_PDF_BASE_URL}/mcp"
-# optional
-export ECHO_PDF_MCP_KEY="<your-mcp-key>"
-```
-
-### Local-first quick start
+最短路径：
 
 ```bash
 npm i -g @echofiles/echo-pdf
-echo-pdf dev --port 8787
+echo-pdf document index ./sample.pdf
+echo-pdf document structure ./sample.pdf
+echo-pdf document page ./sample.pdf --page 1
 ```
 
-`echo-pdf dev` 启动时会打印可直接给下游使用的：
+默认会在当前目录写入可检查的 workspace：
 
-- `ECHO_PDF_BASE_URL`
-- `ECHO_PDF_MCP_URL`
-
-健康检查与能力检查：
-
-```bash
-curl -sS "$ECHO_PDF_BASE_URL/health"
-curl -sS "$ECHO_PDF_BASE_URL/tools/catalog"
+```text
+.echo-pdf-workspace/
+  documents/<documentId>/
+    document.json
+    structure.json
+    pages/
+      0001.json
+      0002.json
+      ...
 ```
 
-### Recommended call flow (downstream)
+这些 artifacts 会在 PDF 未变化时被复用，便于本地下游产品（例如 echo-datasheet）做增量读取。
 
-1. 下游先做 ingest（例如 `echo_pdf_ingest`），上传 PDF 到 `POST /api/files/upload`，得到 `echoPdfFileId`。  
-2. 下游通过 MCP/HTTP 调工具，并传 `fileId=echoPdfFileId`：
-  - `pdf_extract_pages`
-  - `pdf_ocr_pages`
-  - `pdf_tables_to_latex`
+## Local library/client API
 
-MCP-first 示例：
+当前阶段优先提供本地可组合 primitives，让下游产品直接围绕 PDF 建立 document metadata / page-level artifacts，而不是先依赖远端 MCP/SaaS。
 
-```bash
-curl -sS -X POST "$ECHO_PDF_MCP_URL" \
-  -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pdf_extract_pages","arguments":{"fileId":"<FILE_ID>","pages":[1]}}}'
+### Local-first entrypoints（semver 稳定）
+
+- `@echofiles/echo-pdf`：core API
+- `@echofiles/echo-pdf/core`：与根入口等价的 core API
+- `@echofiles/echo-pdf/local`：本地 document primitives
+- `@echofiles/echo-pdf/worker`：兼容保留的 Worker 路由入口，不是本阶段重点
+
+### Local document primitives
+
+```ts
+import {
+  get_document,
+  get_document_structure,
+  get_page_content,
+} from "@echofiles/echo-pdf/local"
+
+const doc = await get_document({ pdfPath: "./sample.pdf" })
+const structure = await get_document_structure({ pdfPath: "./sample.pdf" })
+const page1 = await get_page_content({ pdfPath: "./sample.pdf", pageNumber: 1 })
 ```
 
-HTTP fallback 示例：
+这些调用会把 artifacts 写入本地 workspace，并在 PDF 未变化时尽量复用已有页面结果。
 
-```bash
-curl -sS -X POST "$ECHO_PDF_BASE_URL/tools/call" \
-  -H 'content-type: application/json' \
-  -d '{"name":"pdf_extract_pages","arguments":{"fileId":"<FILE_ID>","pages":[1]}}'
-```
+当前 `get_document_structure()` 返回的是最小可复用 page index：`document -> pages[]`。它还不是 section/headings 级别的语义树，文档承诺也只到这里。
 
-## Using echo-pdf as a library
+## Tool library compatibility
 
-`@echofiles/echo-pdf` 支持直接作为库导入，面向下游复用 `pdf_extract_pages / pdf_ocr_pages / pdf_tables_to_latex / file_ops` 工具实现。
+除了 local-first primitives 之外，`@echofiles/echo-pdf` 仍保留现有 `pdf_extract_pages / pdf_ocr_pages / pdf_tables_to_latex / file_ops` 工具实现的复用入口，用于兼容已有集成。
 
 ### Public entrypoints（semver 稳定）
 
-- `@echofiles/echo-pdf`：core API（推荐）
+- `@echofiles/echo-pdf`：core API
 - `@echofiles/echo-pdf/core`：与根入口等价的 core API
-- `@echofiles/echo-pdf/worker`：Worker 路由入口（给 Wrangler/Worker 集成用）
+- `@echofiles/echo-pdf/local`：本地 document primitives
+- `@echofiles/echo-pdf/worker`：Worker 路由入口（兼容保留）
 
 仅以上 `exports` 子路径视为公开 API。`src/*`、`dist/*` 等深路径导入不受兼容性承诺保护，可能在次版本中变动。
 
@@ -87,6 +90,7 @@ curl -sS -X POST "$ECHO_PDF_BASE_URL/tools/call" \
 
 - Node.js: `>=20`（与 `package.json#engines` 一致）
 - 需要 ESM `import` 能力与标准 `fetch`（Node 20+ 原生支持）
+- `@echofiles/echo-pdf/local` 面向本地 Node/Bun CLI 或 app runtime
 - 建议使用支持 package `exports` 的现代 bundler/runtime（Vite、Webpack 5、Rspack、esbuild、Wrangler 等）
 - TypeScript 消费方建议：`module=NodeNext` + `moduleResolution=NodeNext`
 
@@ -99,7 +103,7 @@ tmpdir="$(mktemp -d)"
 cd "$tmpdir"
 npm init -y
 npm i /path/to/echofiles-echo-pdf-<version>.tgz
-node --input-type=module -e "await import('@echofiles/echo-pdf'); await import('@echofiles/echo-pdf/core'); await import('@echofiles/echo-pdf/worker'); console.log('ok')"
+node --input-type=module -e "await import('@echofiles/echo-pdf'); await import('@echofiles/echo-pdf/core'); await import('@echofiles/echo-pdf/local'); await import('@echofiles/echo-pdf/worker'); console.log('ok')"
 ```
 
 ### Example
@@ -145,7 +149,7 @@ console.log(result)
 - 对公开 API 的破坏性变更只会在 major 版本发布
 - 新增导出、参数扩展（向后兼容）会在 minor/patch 发布
 
-## 1. 服务地址
+## 1. Existing service surfaces（compatibility）
 
 请先确定你的线上地址（Worker 域名）。文档里用：
 
@@ -217,7 +221,39 @@ echo-pdf config set --key service.storage.maxFileBytes --value 10000000
 echo-pdf config set --key service.maxPagesPerRequest --value 20
 ```
 
-## 3. MCP 使用（推荐）
+## 2.1 本地文档索引与读取
+
+建立本地索引并输出 metadata：
+
+```bash
+echo-pdf document index ./sample.pdf
+```
+
+读取 document metadata：
+
+```bash
+echo-pdf document get ./sample.pdf
+```
+
+读取结构树：
+
+```bash
+echo-pdf document structure ./sample.pdf
+```
+
+读取指定页面内容：
+
+```bash
+echo-pdf document page ./sample.pdf --page 1
+```
+
+自定义 artifact workspace：
+
+```bash
+echo-pdf document index ./sample.pdf --workspace ./.cache/echo-pdf
+```
+
+## 3. MCP 使用（兼容保留，非本阶段重点）
 
 ### 3.1 检查 MCP 服务可用
 

--- a/bin/echo-pdf.js
+++ b/bin/echo-pdf.js
@@ -323,6 +323,23 @@ const writeDevVarsConfigJson = (devVarsPath, configJson) => {
   fs.writeFileSync(devVarsPath, lines.join("\n"))
 }
 
+const LOCAL_DOCUMENT_DIST_ENTRY = new URL("../dist/local/index.js", import.meta.url)
+
+const loadLocalDocumentApi = async () => {
+  try {
+    return await import(LOCAL_DOCUMENT_DIST_ENTRY.href)
+  } catch (error) {
+    const code = error && typeof error === "object" ? error.code : ""
+    if (code === "ERR_MODULE_NOT_FOUND") {
+      throw new Error(
+        "Local document commands require built artifacts in a source checkout. " +
+        "Run `npm run build` first, or install the published package."
+      )
+    }
+    throw error
+  }
+}
+
 const usage = () => {
   process.stdout.write(`echo-pdf CLI\n\n`)
   process.stdout.write(`Commands:\n`)
@@ -338,6 +355,10 @@ const usage = () => {
   process.stdout.write(`  model list [--profile name]\n`)
   process.stdout.write(`  tools\n`)
   process.stdout.write(`  call --tool <name> --args '<json>' [--provider alias] [--model model] [--profile name] [--auto-upload]\n`)
+  process.stdout.write(`  document index <file.pdf> [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  document get <file.pdf> [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  document structure <file.pdf> [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  document page <file.pdf> --page <N> [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  file upload <local.pdf>\n`)
   process.stdout.write(`  file get --file-id <id> --out <path>\n`)
   process.stdout.write(`  mcp initialize\n`)
@@ -432,7 +453,7 @@ const main = async () => {
   const [command, ...raw] = argv
   let subcommand = ""
   let rest = raw
-  if (["provider", "mcp", "setup", "model", "config"].includes(command)) {
+  if (["provider", "mcp", "setup", "model", "config", "document"].includes(command)) {
     subcommand = raw[0] || ""
     rest = raw.slice(1)
   }
@@ -586,6 +607,36 @@ const main = async () => {
     if (!response.ok) throw new Error(JSON.stringify(data))
     print(data)
     return
+  }
+
+  if (command === "document") {
+    const local = await loadLocalDocumentApi()
+    const pdfPath = rest[0]
+    const workspaceDir = typeof flags.workspace === "string" ? flags.workspace : undefined
+    const forceRefresh = flags["force-refresh"] === true
+    if (typeof pdfPath !== "string" || pdfPath.length === 0) {
+      throw new Error("document command requires a pdf path argument")
+    }
+    if (subcommand === "index" || subcommand === "get") {
+      const data = await local.get_document({ pdfPath, workspaceDir, forceRefresh })
+      print(data)
+      return
+    }
+    if (subcommand === "structure") {
+      const data = await local.get_document_structure({ pdfPath, workspaceDir, forceRefresh })
+      print(data)
+      return
+    }
+    if (subcommand === "page") {
+      const pageNumber = typeof flags.page === "string" ? Number(flags.page) : NaN
+      if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+        throw new Error("document page requires --page <positive integer>")
+      }
+      const data = await local.get_page_content({ pdfPath, workspaceDir, forceRefresh, pageNumber })
+      print(data)
+      return
+    }
+    throw new Error("document command supports: index|get|structure|page")
   }
 
   if (command === "call") {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echofiles/echo-pdf",
-  "description": "MCP-first PDF agent on Cloudflare Workers with CLI and web demo.",
+  "description": "Local-first PDF document component core with CLI, workspace artifacts, and reusable page primitives.",
   "version": "0.4.2",
   "type": "module",
   "publishConfig": {
@@ -19,6 +19,10 @@
     "./core": {
       "types": "./dist/core/index.d.ts",
       "import": "./dist/core/index.js"
+    },
+    "./local": {
+      "types": "./dist/local/index.d.ts",
+      "import": "./dist/local/index.js"
     },
     "./worker": {
       "types": "./dist/worker.d.ts",

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -1,0 +1,246 @@
+/// <reference path="../node/compat.d.ts" />
+
+import { createHash } from "node:crypto"
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { extractLocalPdfPageText, getLocalPdfPageCount } from "../node/pdfium-local.js"
+import { loadEchoPdfConfig } from "../pdf-config.js"
+import type { EchoPdfConfig } from "../pdf-types.js"
+
+export interface LocalDocumentArtifactPaths {
+  readonly workspaceDir: string
+  readonly documentDir: string
+  readonly documentJsonPath: string
+  readonly structureJsonPath: string
+  readonly pagesDir: string
+}
+
+export interface LocalDocumentMetadata {
+  readonly documentId: string
+  readonly sourcePath: string
+  readonly filename: string
+  readonly sizeBytes: number
+  readonly mtimeMs: number
+  readonly pageCount: number
+  readonly indexedAt: string
+  readonly cacheStatus: "fresh" | "reused"
+  readonly artifactPaths: LocalDocumentArtifactPaths
+}
+
+export interface LocalDocumentStructureNode {
+  readonly id: string
+  readonly type: "document" | "page"
+  readonly title: string
+  readonly pageNumber?: number
+  readonly preview?: string
+  readonly artifactPath?: string
+  readonly children?: ReadonlyArray<LocalDocumentStructureNode>
+}
+
+export interface LocalDocumentStructure {
+  readonly documentId: string
+  readonly generatedAt: string
+  readonly root: LocalDocumentStructureNode
+}
+
+export interface LocalPageContent {
+  readonly documentId: string
+  readonly pageNumber: number
+  readonly title: string
+  readonly preview: string
+  readonly text: string
+  readonly chars: number
+  readonly artifactPath: string
+}
+
+export interface LocalDocumentRequest {
+  readonly pdfPath: string
+  readonly workspaceDir?: string
+  readonly forceRefresh?: boolean
+  readonly config?: EchoPdfConfig
+}
+
+export interface LocalPageContentRequest extends LocalDocumentRequest {
+  readonly pageNumber: number
+}
+
+interface StoredDocumentRecord {
+  readonly documentId: string
+  readonly sourcePath: string
+  readonly filename: string
+  readonly sizeBytes: number
+  readonly mtimeMs: number
+  readonly pageCount: number
+  readonly indexedAt: string
+  readonly artifactPaths: LocalDocumentArtifactPaths
+}
+
+const defaultWorkspaceDir = (): string => path.resolve(process.cwd(), ".echo-pdf-workspace")
+
+const resolveWorkspaceDir = (workspaceDir?: string): string =>
+  path.resolve(process.cwd(), workspaceDir?.trim() || defaultWorkspaceDir())
+
+const toDocumentId = (absolutePdfPath: string): string =>
+  createHash("sha256").update(absolutePdfPath).digest("hex").slice(0, 16)
+
+const buildArtifactPaths = (workspaceDir: string, documentId: string): LocalDocumentArtifactPaths => {
+  const documentDir = path.join(workspaceDir, "documents", documentId)
+  return {
+    workspaceDir,
+    documentDir,
+    documentJsonPath: path.join(documentDir, "document.json"),
+    structureJsonPath: path.join(documentDir, "structure.json"),
+    pagesDir: path.join(documentDir, "pages"),
+  }
+}
+
+const createPreview = (text: string): string => text.replace(/\s+/g, " ").trim().slice(0, 160)
+
+const createPageTitle = (pageNumber: number, text: string): string => {
+  const firstLine = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0)
+  return firstLine ? `Page ${pageNumber}: ${firstLine.slice(0, 80)}` : `Page ${pageNumber}`
+}
+
+const resolveConfig = (config?: EchoPdfConfig): EchoPdfConfig => config ?? loadEchoPdfConfig({} as never)
+
+const fileExists = async (targetPath: string): Promise<boolean> => {
+  try {
+    await stat(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const loadStoredDocument = async (paths: LocalDocumentArtifactPaths): Promise<StoredDocumentRecord | null> => {
+  if (!await fileExists(paths.documentJsonPath)) return null
+  const raw = await readFile(paths.documentJsonPath, "utf-8")
+  return JSON.parse(raw) as StoredDocumentRecord
+}
+
+const isReusableRecord = async (
+  record: StoredDocumentRecord,
+  sourceStats: { sizeBytes: number; mtimeMs: number },
+  paths: LocalDocumentArtifactPaths
+): Promise<boolean> => {
+  if (record.sizeBytes !== sourceStats.sizeBytes || record.mtimeMs !== sourceStats.mtimeMs) return false
+  if (!await fileExists(paths.structureJsonPath)) return false
+  for (let pageNumber = 1; pageNumber <= record.pageCount; pageNumber += 1) {
+    const pagePath = path.join(paths.pagesDir, `${String(pageNumber).padStart(4, "0")}.json`)
+    if (!await fileExists(pagePath)) return false
+  }
+  return true
+}
+
+const writeJson = async (targetPath: string, data: unknown): Promise<void> => {
+  await mkdir(path.dirname(targetPath), { recursive: true })
+  await writeFile(targetPath, `${JSON.stringify(data, null, 2)}\n`, "utf-8")
+}
+
+const indexDocumentInternal = async (
+  request: LocalDocumentRequest
+): Promise<{ record: StoredDocumentRecord; reused: boolean }> => {
+  const config = resolveConfig(request.config)
+  const sourcePath = path.resolve(process.cwd(), request.pdfPath)
+  const workspaceDir = resolveWorkspaceDir(request.workspaceDir)
+  const documentId = toDocumentId(sourcePath)
+  const artifactPaths = buildArtifactPaths(workspaceDir, documentId)
+  const sourceFile = await readFile(sourcePath)
+  const sourceStats = await stat(sourcePath)
+  const stored = await loadStoredDocument(artifactPaths)
+  const sourceMeta = {
+    sizeBytes: sourceStats.size,
+    mtimeMs: sourceStats.mtimeMs,
+  }
+
+  if (!request.forceRefresh && stored && await isReusableRecord(stored, sourceMeta, artifactPaths)) {
+    return { record: stored, reused: true }
+  }
+
+  await mkdir(artifactPaths.pagesDir, { recursive: true })
+  const bytes = new Uint8Array(sourceFile)
+  const pageCount = await getLocalPdfPageCount(config, bytes)
+  const pageNodes: LocalDocumentStructureNode[] = []
+
+  for (let pageNumber = 1; pageNumber <= pageCount; pageNumber += 1) {
+    const text = await extractLocalPdfPageText(config, bytes, pageNumber - 1)
+    const preview = createPreview(text)
+    const title = createPageTitle(pageNumber, text)
+    const artifactPath = path.join(artifactPaths.pagesDir, `${String(pageNumber).padStart(4, "0")}.json`)
+    const pageArtifact: LocalPageContent = {
+      documentId,
+      pageNumber,
+      title,
+      preview,
+      text,
+      chars: text.length,
+      artifactPath,
+    }
+    await writeJson(artifactPath, pageArtifact)
+    pageNodes.push({
+      id: `page-${pageNumber}`,
+      type: "page",
+      title,
+      pageNumber,
+      preview,
+      artifactPath,
+    })
+  }
+
+  const structure: LocalDocumentStructure = {
+    documentId,
+    generatedAt: new Date().toISOString(),
+    root: {
+      id: documentId,
+      type: "document",
+      title: path.basename(sourcePath),
+      children: pageNodes,
+    },
+  }
+  await writeJson(artifactPaths.structureJsonPath, structure)
+
+  const documentRecord: StoredDocumentRecord = {
+    documentId,
+    sourcePath,
+    filename: path.basename(sourcePath),
+    sizeBytes: sourceMeta.sizeBytes,
+    mtimeMs: sourceMeta.mtimeMs,
+    pageCount,
+    indexedAt: structure.generatedAt,
+    artifactPaths,
+  }
+  await writeJson(artifactPaths.documentJsonPath, documentRecord)
+  return { record: documentRecord, reused: false }
+}
+
+const toMetadata = (
+  record: StoredDocumentRecord,
+  cacheStatus: "fresh" | "reused"
+): LocalDocumentMetadata => ({
+  ...record,
+  cacheStatus,
+})
+
+export const get_document = async (request: LocalDocumentRequest): Promise<LocalDocumentMetadata> => {
+  const { record, reused } = await indexDocumentInternal(request)
+  return toMetadata(record, reused ? "reused" : "fresh")
+}
+
+export const get_document_structure = async (request: LocalDocumentRequest): Promise<LocalDocumentStructure> => {
+  const { record } = await indexDocumentInternal(request)
+  const raw = await readFile(record.artifactPaths.structureJsonPath, "utf-8")
+  return JSON.parse(raw) as LocalDocumentStructure
+}
+
+export const get_page_content = async (request: LocalPageContentRequest): Promise<LocalPageContent> => {
+  const { record } = await indexDocumentInternal(request)
+  if (!Number.isInteger(request.pageNumber) || request.pageNumber < 1 || request.pageNumber > record.pageCount) {
+    throw new Error(`pageNumber must be within 1..${record.pageCount}`)
+  }
+  const pagePath = path.join(record.artifactPaths.pagesDir, `${String(request.pageNumber).padStart(4, "0")}.json`)
+  const raw = await readFile(pagePath, "utf-8")
+  return JSON.parse(raw) as LocalPageContent
+}

--- a/src/node/compat.d.ts
+++ b/src/node/compat.d.ts
@@ -1,0 +1,60 @@
+declare const process: {
+  cwd(): string
+  versions?: {
+    node?: string
+  }
+}
+
+interface ImportMeta {
+  url: string
+}
+
+declare module "node:crypto" {
+  interface Hash {
+    update(data: string | ArrayBuffer | ArrayBufferView): Hash
+    digest(encoding: "hex"): string
+  }
+
+  export function createHash(algorithm: string): Hash
+}
+
+declare module "node:fs/promises" {
+  export interface FileStat {
+    size: number
+    mtimeMs: number
+  }
+
+  export function mkdir(
+    path: string,
+    options?: {
+      recursive?: boolean
+    }
+  ): Promise<string | undefined>
+
+  export function readFile(path: string, encoding: "utf-8"): Promise<string>
+  export function readFile(path: string): Promise<Uint8Array>
+  export function writeFile(path: string, data: string | Uint8Array, encoding?: "utf-8"): Promise<void>
+  export function stat(path: string): Promise<FileStat>
+}
+
+declare module "node:module" {
+  export function createRequire(filename: string): {
+    resolve(specifier: string): string
+  }
+}
+
+declare module "node:path" {
+  export function resolve(...paths: string[]): string
+  export function join(...paths: string[]): string
+  export function dirname(path: string): string
+  export function basename(path: string): string
+
+  const pathApi: {
+    resolve: typeof resolve
+    join: typeof join
+    dirname: typeof dirname
+    basename: typeof basename
+  }
+
+  export default pathApi
+}

--- a/src/node/pdfium-local.ts
+++ b/src/node/pdfium-local.ts
@@ -1,0 +1,119 @@
+/// <reference path="./compat.d.ts" />
+
+import { init } from "@embedpdf/pdfium"
+import type { WrappedPdfiumModule } from "@embedpdf/pdfium"
+import type { EchoPdfConfig } from "../pdf-types.js"
+
+let moduleInstance: WrappedPdfiumModule | null = null
+let libraryInitialized = false
+
+const isNodeRuntime = (): boolean =>
+  typeof process !== "undefined" && Boolean(process.versions?.node)
+
+const ensureWasmFunctionShim = (): void => {
+  const wasmApi = WebAssembly as unknown as {
+    Function?: unknown
+  }
+  if (typeof wasmApi.Function === "function") return
+  ;(wasmApi as { Function: (sig: unknown, fn: unknown) => unknown }).Function = (
+    _sig: unknown,
+    fn: unknown
+  ) => fn
+}
+
+const readLocalPdfiumWasm = async (): Promise<ArrayBuffer> => {
+  const [{ readFile }, { createRequire }] = await Promise.all([
+    import("node:fs/promises"),
+    import("node:module"),
+  ])
+  const require = createRequire(import.meta.url)
+  const bytes = await readFile(require.resolve("@embedpdf/pdfium/pdfium.wasm"))
+  return new Uint8Array(bytes).slice().buffer
+}
+
+const ensureLocalPdfium = async (_config: EchoPdfConfig): Promise<WrappedPdfiumModule> => {
+  if (!isNodeRuntime()) {
+    throw new Error("local document APIs require a Node-compatible runtime")
+  }
+  ensureWasmFunctionShim()
+  if (!moduleInstance) {
+    moduleInstance = await init({ wasmBinary: await readLocalPdfiumWasm() })
+  }
+  if (!libraryInitialized) {
+    moduleInstance.FPDF_InitLibrary()
+    libraryInitialized = true
+  }
+  return moduleInstance
+}
+
+const makeDoc = (pdfium: WrappedPdfiumModule, bytes: Uint8Array): {
+  readonly doc: number
+  readonly memPtr: number
+} => {
+  const memPtr = pdfium.pdfium.wasmExports.malloc(bytes.length)
+  ;(pdfium.pdfium as unknown as { HEAPU8: Uint8Array }).HEAPU8.set(bytes, memPtr)
+  const doc = pdfium.FPDF_LoadMemDocument(memPtr, bytes.length, "")
+  if (!doc) {
+    pdfium.pdfium.wasmExports.free(memPtr)
+    throw new Error("Failed to load PDF document")
+  }
+  return { doc, memPtr }
+}
+
+const closeDoc = (pdfium: WrappedPdfiumModule, doc: number, memPtr: number): void => {
+  pdfium.FPDF_CloseDocument(doc)
+  pdfium.pdfium.wasmExports.free(memPtr)
+}
+
+const decodeUtf16Le = (buf: Uint8Array): string => {
+  const view = new Uint16Array(buf.buffer, buf.byteOffset, Math.floor(buf.byteLength / 2))
+  const chars: number[] = []
+  for (const code of view) {
+    if (code === 0) break
+    chars.push(code)
+  }
+  return String.fromCharCode(...chars)
+}
+
+export const getLocalPdfPageCount = async (config: EchoPdfConfig, bytes: Uint8Array): Promise<number> => {
+  const pdfium = await ensureLocalPdfium(config)
+  const { doc, memPtr } = makeDoc(pdfium, bytes)
+  try {
+    return pdfium.FPDF_GetPageCount(doc)
+  } finally {
+    closeDoc(pdfium, doc, memPtr)
+  }
+}
+
+export const extractLocalPdfPageText = async (
+  config: EchoPdfConfig,
+  bytes: Uint8Array,
+  pageIndex: number
+): Promise<string> => {
+  const pdfium = await ensureLocalPdfium(config)
+  const { doc, memPtr } = makeDoc(pdfium, bytes)
+  let page = 0
+  let textPage = 0
+  let outPtr = 0
+  try {
+    page = pdfium.FPDF_LoadPage(doc, pageIndex)
+    if (!page) {
+      throw new Error(`Failed to load page ${pageIndex}`)
+    }
+    textPage = pdfium.FPDFText_LoadPage(page)
+    if (!textPage) return ""
+    const chars = pdfium.FPDFText_CountChars(textPage)
+    if (chars <= 0) return ""
+    const bytesLen = (chars + 1) * 2
+    outPtr = pdfium.pdfium.wasmExports.malloc(bytesLen)
+    pdfium.FPDFText_GetText(textPage, 0, chars, outPtr)
+    const heap = (pdfium.pdfium as unknown as { HEAPU8: Uint8Array }).HEAPU8
+    const raw = heap.slice(outPtr, outPtr + bytesLen)
+    return decodeUtf16Le(raw).trim()
+  } finally {
+    if (outPtr) pdfium.pdfium.wasmExports.free(outPtr)
+    if (textPage) pdfium.FPDFText_ClosePage(textPage)
+    if (page) pdfium.FPDF_ClosePage(page)
+    closeDoc(pdfium, doc, memPtr)
+  }
+}

--- a/tests/integration/local-document-cli.integration.test.ts
+++ b/tests/integration/local-document-cli.integration.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+import { cp, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { execFile, execFileSync } from "node:child_process"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, "../..")
+const fixturePdf = path.join(rootDir, "fixtures", "smoke.pdf")
+const systemNodeMajor = Number(
+  execFileSync("node", ["-p", "process.versions.node.split('.')[0]"], { encoding: "utf-8" }).trim()
+)
+const itWithNode20 = systemNodeMajor >= 20 ? it : it.skip
+
+const runCli = async (repoDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> => {
+  const { stdout, stderr } = await execFileAsync("node", [path.join(repoDir, "bin", "echo-pdf.js"), ...args], {
+    cwd: repoDir,
+    env: process.env,
+  })
+  return { stdout, stderr }
+}
+
+describe("local document CLI", () => {
+  itWithNode20("indexes and reads a PDF through document commands", async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-"))
+
+    const { stdout: docRaw } = await runCli(rootDir, ["document", "get", fixturePdf, "--workspace", workspaceDir])
+    const doc = JSON.parse(docRaw) as {
+      documentId: string
+      pageCount: number
+      cacheStatus: "fresh" | "reused"
+      artifactPaths: {
+        documentJsonPath: string
+      }
+    }
+    expect(doc.pageCount).toBeGreaterThan(0)
+    expect(doc.cacheStatus).toBe("fresh")
+
+    const { stdout: structureRaw } = await runCli(rootDir, ["document", "structure", fixturePdf, "--workspace", workspaceDir])
+    const structure = JSON.parse(structureRaw) as {
+      documentId: string
+      root: {
+        children?: Array<{ pageNumber?: number }>
+      }
+    }
+    expect(structure.documentId).toBe(doc.documentId)
+    expect(structure.root.children?.[0]?.pageNumber).toBe(1)
+
+    const { stdout: pageRaw } = await runCli(rootDir, ["document", "page", fixturePdf, "--page", "1", "--workspace", workspaceDir])
+    const page = JSON.parse(pageRaw) as {
+      documentId: string
+      pageNumber: number
+      text: string
+    }
+    expect(page.documentId).toBe(doc.documentId)
+    expect(page.pageNumber).toBe(1)
+    expect(typeof page.text).toBe("string")
+
+    const { stdout: docSecondRaw } = await runCli(rootDir, ["document", "get", fixturePdf, "--workspace", workspaceDir])
+    const docSecond = JSON.parse(docSecondRaw) as {
+      cacheStatus: "fresh" | "reused"
+    }
+    expect(docSecond.cacheStatus).toBe("reused")
+
+    const stored = JSON.parse(await readFile(doc.artifactPaths.documentJsonPath, "utf-8")) as {
+      documentId?: string
+    }
+    expect(stored.documentId).toBe(doc.documentId)
+  })
+
+  itWithNode20("fails fast with a build hint when dist artifacts are missing in a source checkout", async () => {
+    const checkoutDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-source-"))
+    await cp(path.join(rootDir, "bin"), path.join(checkoutDir, "bin"), { recursive: true })
+    await cp(path.join(rootDir, "echo-pdf.config.json"), path.join(checkoutDir, "echo-pdf.config.json"))
+    await writeFile(path.join(checkoutDir, "package.json"), `${JSON.stringify({ type: "module" }, null, 2)}\n`, "utf-8")
+
+    let failureMessage = ""
+    try {
+      await runCli(checkoutDir, ["document", "get", fixturePdf])
+    } catch (error) {
+      failureMessage = String(error instanceof Error ? error.message : error)
+    }
+
+    expect(failureMessage).toContain("npm run build")
+    expect(failureMessage).toContain("Local document commands require built artifacts")
+  })
+})

--- a/tests/integration/local-document.integration.test.ts
+++ b/tests/integration/local-document.integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { mkdtemp, readFile, stat } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, "../..")
+const fixturePdf = path.join(rootDir, "fixtures", "smoke.pdf")
+
+describe("local document workflow", () => {
+  it("indexes a PDF into inspectable local artifacts and reuses them", async () => {
+    const local = await import("@echofiles/echo-pdf/local")
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-local-"))
+
+    const first = await local.get_document({ pdfPath: fixturePdf, workspaceDir }) as {
+      documentId: string
+      pageCount: number
+      cacheStatus: "fresh" | "reused"
+      artifactPaths: {
+        documentJsonPath: string
+        structureJsonPath: string
+        pagesDir: string
+      }
+    }
+    expect(first.pageCount).toBeGreaterThan(0)
+    expect(first.cacheStatus).toBe("fresh")
+
+    const structure = await local.get_document_structure({ pdfPath: fixturePdf, workspaceDir }) as {
+      documentId: string
+      root: { children?: Array<{ pageNumber?: number; artifactPath?: string }> }
+    }
+    expect(structure.documentId).toBe(first.documentId)
+    expect(structure.root.children?.length).toBe(first.pageCount)
+    expect(structure.root.children?.[0]?.pageNumber).toBe(1)
+
+    const page = await local.get_page_content({ pdfPath: fixturePdf, workspaceDir, pageNumber: 1 }) as {
+      documentId: string
+      pageNumber: number
+      text: string
+      artifactPath: string
+    }
+    expect(page.documentId).toBe(first.documentId)
+    expect(page.pageNumber).toBe(1)
+    expect(typeof page.text).toBe("string")
+
+    const structureBefore = await stat(first.artifactPaths.structureJsonPath)
+    const second = await local.get_document({ pdfPath: fixturePdf, workspaceDir }) as {
+      cacheStatus: "fresh" | "reused"
+    }
+    const structureAfter = await stat(first.artifactPaths.structureJsonPath)
+    expect(second.cacheStatus).toBe("reused")
+    expect(structureAfter.mtimeMs).toBe(structureBefore.mtimeMs)
+
+    const documentJson = JSON.parse(await readFile(first.artifactPaths.documentJsonPath, "utf-8")) as {
+      documentId?: string
+    }
+    expect(documentJson.documentId).toBe(first.documentId)
+  })
+})

--- a/tests/integration/npm-pack-import.integration.test.ts
+++ b/tests/integration/npm-pack-import.integration.test.ts
@@ -19,7 +19,7 @@ const run = async (cmd: string, args: string[], cwd: string): Promise<string> =>
 }
 
 describe("npm pack import smoke", () => {
-  it("imports package root/core/worker from packed artifact", async () => {
+  it("imports package root/core/local/worker from packed artifact", async () => {
     const packJson = await run("npm", ["pack", "--json"], rootDir)
     const parsed = JSON.parse(packJson) as Array<{ filename?: string }>
     const filename = parsed[0]?.filename
@@ -33,9 +33,11 @@ describe("npm pack import smoke", () => {
       const code = [
         "const root = await import('@echofiles/echo-pdf')",
         "const core = await import('@echofiles/echo-pdf/core')",
+        "const local = await import('@echofiles/echo-pdf/local')",
         "const worker = await import('@echofiles/echo-pdf/worker')",
         "if (typeof root.callTool !== 'function') throw new Error('root.callTool missing')",
         "if (typeof core.listToolSchemas !== 'function') throw new Error('core.listToolSchemas missing')",
+        "if (typeof local.get_document !== 'function') throw new Error('local.get_document missing')",
         "if (!worker.default || typeof worker.default.fetch !== 'function') throw new Error('worker.fetch missing')",
         "console.log('ok')",
       ].join(";")

--- a/tests/integration/ts-nodenext-consumer.integration.test.ts
+++ b/tests/integration/ts-nodenext-consumer.integration.test.ts
@@ -16,7 +16,7 @@ const run = async (cmd: string, args: string[], cwd: string): Promise<string> =>
 }
 
 describe("ts nodenext consumer smoke", () => {
-  it("typechecks package root/core/worker imports in a fresh consumer", async () => {
+  it("typechecks package root/core/local/worker imports in a fresh consumer", async () => {
     const packJson = await run("npm", ["pack", "--json"], rootDir)
     const parsed = JSON.parse(packJson) as Array<{ filename?: string }>
     const filename = parsed[0]?.filename
@@ -32,9 +32,11 @@ describe("ts nodenext consumer smoke", () => {
       await writeFile(path.join(tempDir, "index.ts"), [
         "import * as pkg from '@echofiles/echo-pdf'",
         "import * as core from '@echofiles/echo-pdf/core'",
+        "import * as local from '@echofiles/echo-pdf/local'",
         "import worker from '@echofiles/echo-pdf/worker'",
         "pkg.listToolSchemas()",
         "core.listToolSchemas()",
+        "local.get_document",
         "worker",
         "",
       ].join("\n"))


### PR DESCRIPTION
## Summary
- reposition `echo-pdf` toward a local-first document component core for issue #33
- add Node-only local document primitives via `@echofiles/echo-pdf/local`
- add local CLI document commands and local workspace artifacts for document/page inspection
- tighten docs and tests around the actual current capability boundary (`document -> pages[]` page index)

## Runtime boundaries
- `src/node/*`: Node-only local pdfium loader and node compatibility shims
- `src/local/*`: local-first document artifact/index workflow built on the Node-only loader
- existing Worker/shared paths remain isolated; local APIs are not re-exported from root/core
- CLI `document` subcommands explicitly fail fast in a source checkout when `dist/` has not been built yet

## What changed
- added `get_document`, `get_document_structure`, and `get_page_content` under `@echofiles/echo-pdf/local`
- persist local workspace artifacts under `.echo-pdf-workspace/documents/<documentId>/...`
- added `echo-pdf document index|get|structure|page`
- added no-mock local integration coverage for library and CLI flows
- added a source-checkout smoke assertion for the missing-`dist` fail-fast path
- updated README to describe the current page-level artifact/index scope and demote MCP/SaaS as non-focus for this phase
- ignored local review/tarball noise (`_deepreview/`, `_prfix/`, `*.tgz`)

## Validation
Ran under explicit `Node v20.20.1` from `/Users/huangjinfeng/.nvm/versions/node/v20.20.1/bin/node`.

Main feedback loop:
- `npm run build`
- `npm run typecheck`
- `npm run test:unit`
- `npx vitest run tests/integration/local-document.integration.test.ts tests/integration/local-document-cli.integration.test.ts`

Publish/distribution smoke:
- `npm pack --json` with `npm_config_cache=/tmp/echo-pdf-npm-cache`
- `npx vitest run tests/integration/npm-pack-import.integration.test.ts tests/integration/ts-nodenext-consumer.integration.test.ts` with `npm_config_cache=/tmp/echo-pdf-npm-cache`
  - note: `ts-nodenext-consumer` required a longer timeout in this environment because fresh consumer install/typecheck exceeded Vitest's default 120s, but it passed once rerun with a higher timeout

## Not run
- full port-based / wrangler-backed integration flows unrelated to #33 were not used as the main feedback loop for this PR

Refs #33
