### PR TITLE
chore(cli-dev): support a clean source-checkout workflow for local document commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ npm run document:dev -- page ./fixtures/smoke.pdf --page 1
 
 - 发布包 / 已构建 checkout：`echo-pdf document ...` 继续走 `dist/`
 - 源码 checkout 且还没 build：使用 `npm run document:dev -- ...`
-- `document:dev` 只用于本地开发；它在 Bun 下直接加载 `src/local/index.ts`，不改变发布包行为
+- `document:dev` 只用于本地开发；它会显式优先加载 `src/local/index.ts`，即使仓库里仍然存在旧 `dist/`
+- 发布包和正常 `echo-pdf document ...` 仍然只走 `dist/`
 
 默认会在当前目录写入可检查的 workspace：
 

--- a/bin/echo-pdf.js
+++ b/bin/echo-pdf.js
@@ -326,19 +326,22 @@ const writeDevVarsConfigJson = (devVarsPath, configJson) => {
 const LOCAL_DOCUMENT_DIST_ENTRY = new URL("../dist/local/index.js", import.meta.url)
 const LOCAL_DOCUMENT_SOURCE_ENTRY = new URL("../src/local/index.ts", import.meta.url)
 const IS_BUN_RUNTIME = typeof process.versions?.bun === "string"
+const SHOULD_PREFER_SOURCE_DOCUMENT_API = process.env.ECHO_PDF_SOURCE_DEV === "1"
 
 const loadLocalDocumentApi = async () => {
+  if (SHOULD_PREFER_SOURCE_DOCUMENT_API) {
+    if (IS_BUN_RUNTIME && fs.existsSync(fileURLToPath(LOCAL_DOCUMENT_SOURCE_ENTRY))) {
+      return import(LOCAL_DOCUMENT_SOURCE_ENTRY.href)
+    }
+    throw new Error(
+      "Source-checkout document dev mode requires Bun and src/local/index.ts. " +
+      "Use `npm run document:dev -- <subcommand> ...` from a source checkout."
+    )
+  }
   try {
     return await import(LOCAL_DOCUMENT_DIST_ENTRY.href)
   } catch (error) {
     const code = error && typeof error === "object" ? error.code : ""
-    if (
-      code === "ERR_MODULE_NOT_FOUND" &&
-      IS_BUN_RUNTIME &&
-      fs.existsSync(fileURLToPath(LOCAL_DOCUMENT_SOURCE_ENTRY))
-    ) {
-      return import(LOCAL_DOCUMENT_SOURCE_ENTRY.href)
-    }
     if (code === "ERR_MODULE_NOT_FOUND") {
       throw new Error(
         "Local document commands require built artifacts in a source checkout. " +

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check:runtime": "bash ./scripts/check-runtime.sh",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "document:dev": "bun ./bin/echo-pdf.js document",
+    "document:dev": "ECHO_PDF_SOURCE_DEV=1 bun ./bin/echo-pdf.js document",
     "typecheck": "npm run check:runtime && tsc --noEmit",
     "test:unit": "npm run check:runtime && vitest run tests/unit",
     "test:import-smoke": "npm run check:runtime && npm run build && vitest run tests/integration/npm-pack-import.integration.test.ts tests/integration/ts-nodenext-consumer.integration.test.ts",

--- a/tests/integration/local-document-cli.integration.test.ts
+++ b/tests/integration/local-document-cli.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { cp, mkdtemp, readFile, symlink } from "node:fs/promises"
+import { cp, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
@@ -106,13 +106,19 @@ describe("local document CLI", () => {
     expect(stored.documentId).toBe(doc.documentId)
   })
 
-  itWithNode20AndBun("supports a source-checkout document workflow without dist artifacts", async () => {
+  itWithNode20AndBun("supports a source-checkout document workflow even when dist artifacts exist", async () => {
     const checkoutDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-source-"))
     await cp(path.join(rootDir, "bin"), path.join(checkoutDir, "bin"), { recursive: true })
+    await cp(path.join(rootDir, "dist"), path.join(checkoutDir, "dist"), { recursive: true })
     await cp(path.join(rootDir, "src"), path.join(checkoutDir, "src"), { recursive: true })
     await cp(path.join(rootDir, "echo-pdf.config.json"), path.join(checkoutDir, "echo-pdf.config.json"))
     await cp(path.join(rootDir, "package.json"), path.join(checkoutDir, "package.json"))
     await symlink(path.join(rootDir, "node_modules"), path.join(checkoutDir, "node_modules"), "dir")
+    await writeFile(
+      path.join(checkoutDir, "dist", "local", "index.js"),
+      'throw new Error("dist local entry should not load in document:dev");\n',
+      "utf-8"
+    )
 
     const { stdout } = await runSourceCheckoutDocumentDev(checkoutDir, ["get", fixturePdf, "--workspace", checkoutDir])
     const doc = JSON.parse(stdout.replace(/^>.*\n/gm, "").trim()) as {


### PR DESCRIPTION
Closes #36

## Summary
- add a clear source-checkout workflow for `document` CLI development without requiring prebuilt `dist/`
- keep published package behavior unchanged
- document and test the supported source-checkout path

## Runtime Boundaries
- published package and built checkouts still load `dist/local/index.js`
- source-checkout fallback is only enabled when running the CLI under Bun and `src/local/index.ts` is present
- no Worker/shared runtime changes; no changes to OCR/render/semantic logic beyond how the CLI loads the local API in dev

## Supported Source-Checkout Workflow
- `npm install`
- `npm run document:dev -- get ./fixtures/smoke.pdf`
- `npm run document:dev -- structure ./fixtures/smoke.pdf`
- `npm run document:dev -- page ./fixtures/smoke.pdf --page 1`

## Validation
- `bun run build`
- `test -f dist/local/index.js`
- `bun run typecheck`
- `bun run test:unit`
- `bunx vitest run tests/integration/local-document-cli.integration.test.ts`
- `bunx vitest run tests/integration/npm-pack-import.integration.test.ts tests/integration/ts-nodenext-consumer.integration.test.ts --testTimeout=400000`

## Untested / Notes
- the source-checkout workflow intentionally uses Bun as the dev-only loader for `src/local/index.ts`
- published package behavior remains on the existing `dist` path; no package export changes in this PR
