### PR TITLE
docs: define local-first product positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # echo-pdf
 
-`echo-pdf` 当前阶段定位为本地优先的 document component core，支持：
+`echo-pdf` 当前阶段定位为本地优先的 PDF context engine for AI agents。
+
+一句话定义：
+
+- 把本地 PDF 处理成可复用的 CLI outputs、library primitives 和 workspace artifacts，供本机 agent/app 继续消费。
+
+当前主线产品形态：
+
+- npm package：`@echofiles/echo-pdf`
+- CLI：`echo-pdf ...`
+- 本地 workspace artifacts：`.echo-pdf-workspace/...`
+- 文档站：仅用于说明安装、CLI、artifacts 和集成契约，不提供在线处理服务
+
+目标用户与主要用法：
+
+- 需要在本机或本地开发环境处理 PDF 的 agent / IDE / app 开发者
+- 需要稳定页级 primitives、document context 和可缓存 artifacts 的下游集成方
+- 需要 clean consumer import + CLI workflow 的本地组件使用方
+
+当前阶段能力：
 
 - 页面提取：把 PDF 指定页渲染为图片
 - OCR：识别页面文本
@@ -14,11 +33,19 @@
 - 本地 CLI
 - 本地 library/client API
 - 本地 workspace artifacts
+- clean-consumer npm package
 
 当前阶段非重点：
 
-- MCP 扩展
+- MCP 扩展或把 MCP 作为主入口
 - Hosted SaaS / multi-tenant 平台能力
+- 把网站做成在线 PDF 服务
+- datasheet / EDA 等领域特化逻辑
+
+进一步的定位说明见：
+
+- [`docs/PRODUCT.md`](./docs/PRODUCT.md)
+- [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md)
 
 ## Local-first workflow
 
@@ -200,7 +227,10 @@ console.log(result)
 - 对公开 API 的破坏性变更只会在 major 版本发布
 - 新增导出、参数扩展（向后兼容）会在 minor/patch 发布
 
-## 1. Existing service surfaces（compatibility）
+## 1. Compatibility surfaces（deferred / not primary）
+
+以下内容是当前仓库中兼容保留的入口，不是本阶段主线产品形态。
+主线仍然是 npm package + CLI + local workspace artifacts；网站只是文档站，不是在线服务。
 
 请先确定你的线上地址（Worker 域名）。文档里用：
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,6 +4,8 @@
 
 `echo-pdf` is now a local-first document component core.
 
+Product positioning lives in [`docs/PRODUCT.md`](./PRODUCT.md). Development choices should follow that product boundary first, then the implementation constraints below.
+
 Priority in this phase:
 
 - local CLI

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,0 +1,52 @@
+# Product Positioning
+
+`echo-pdf` is a local-first PDF context engine for AI agents.
+
+## One-Sentence Definition
+
+`echo-pdf` turns local PDFs into reusable CLI outputs, local library primitives, and inspectable workspace artifacts for downstream local apps and agents.
+
+## Primary Product Surfaces
+
+- npm package: `@echofiles/echo-pdf`
+- local CLI: `echo-pdf ...`
+- local workspace artifacts: `.echo-pdf-workspace/...`
+- documentation site: install and contract docs only
+
+These are the product surfaces that define the current phase. They carry the primary product and semver expectations.
+
+## Target Users
+
+- developers building local AI agents or IDE integrations that need PDF context
+- downstream apps that need stable page-level document primitives and cached local artifacts
+- consumers who want a clean package import plus a local CLI workflow, without depending on a hosted service
+
+## Primary Use Cases
+
+- index a local PDF into reusable page metadata and artifacts
+- render and OCR pages into cacheable local outputs
+- expose stable local document context primitives to a Node/Bun app
+- let downstream local tools reuse the same workspace artifacts instead of reparsing the same file
+
+## Non-Goals For This Phase
+
+- hosted SaaS or multi-tenant platform work
+- treating MCP as the primary product entrypoint
+- turning the website into an online PDF processing service
+- domain-specific extraction logic such as datasheet- or EDA-specific behavior
+- broad tool-surface expansion beyond the core local primitives
+
+## Product Boundary
+
+`echo-pdf` is a general PDF component. It is not the place to encode downstream product policy or domain semantics.
+
+The intended boundary is:
+
+- `echo-pdf` produces general document/page artifacts and primitives
+- downstream products consume those artifacts and add product-specific logic outside this repo
+
+## Secondary / Compatibility Surfaces
+
+Worker and MCP surfaces may remain in the repo for compatibility, but they are not the primary shape of the product in the current phase.
+
+When the docs mention service or Worker endpoints, read them as compatibility surfaces rather than the main adoption path.


### PR DESCRIPTION
## Summary
- define `echo-pdf` as a local-first PDF context engine for AI agents
- make npm package + CLI + workspace artifacts the explicit primary product surfaces
- document that the website is documentation-only, while MCP/service surfaces are compatibility-only and not the current mainline
- make current non-goals explicit: hosted SaaS, MCP-first expansion, and domain-specific logic

## Runtime Boundary
- docs-only change
- no Node / Worker / shared runtime implementation changes

## Validation
- `bun run typecheck`

## Not Run
- unit/integration tests not run because this PR only changes docs and product positioning

Closes #43
