### PR TITLE
docs: lock public package entrypoints and guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 进一步的定位说明见：
 
 - [`docs/PRODUCT.md`](./docs/PRODUCT.md)
+- [`docs/PACKAGING.md`](./docs/PACKAGING.md)
 - [`docs/WORKSPACE_CONTRACT.md`](./docs/WORKSPACE_CONTRACT.md)
 - [`docs/DEVELOPMENT.md`](./docs/DEVELOPMENT.md)
 
@@ -166,6 +167,8 @@ const ocr1 = await get_page_ocr({ pdfPath: "./sample.pdf", pageNumber: 1, model:
 - `@echofiles/echo-pdf/worker`：Worker 路由入口（兼容保留）
 
 仅以上 `exports` 子路径视为公开 API。`src/*`、`dist/*` 等深路径导入不受兼容性承诺保护，可能在次版本中变动。
+
+完整的 package entrypoint、runtime、semver、以及 clean-consumer import 保证，见 [`docs/PACKAGING.md`](./docs/PACKAGING.md)。
 
 ### Runtime expectations
 

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,0 +1,127 @@
+# Package Entrypoints And Integration Guarantees
+
+This document defines the package-level contract for `@echofiles/echo-pdf`.
+
+It tells downstream consumers which imports are public, which runtime expectations are supported, and what a clean consumer install may rely on.
+
+## Supported Public Entrypoints
+
+Only these package entrypoints are public:
+
+- `@echofiles/echo-pdf`
+- `@echofiles/echo-pdf/core`
+- `@echofiles/echo-pdf/local`
+- `@echofiles/echo-pdf/worker`
+
+Entrypoint intent:
+
+- `@echofiles/echo-pdf`
+  - root core API
+  - semver-stable public package surface
+- `@echofiles/echo-pdf/core`
+  - equivalent core API surface to the root entry
+  - semver-stable public package surface
+- `@echofiles/echo-pdf/local`
+  - local-first document primitives for Node/Bun
+  - semver-stable public package surface
+- `@echofiles/echo-pdf/worker`
+  - Worker route entry kept for compatibility
+  - public, but not the primary product surface in the current phase
+
+Everything else is private implementation detail, including:
+
+- `src/*`
+- `dist/*`
+- internal relative modules
+- non-exported files in the published tarball
+
+Downstream consumers must not deep-import private paths.
+
+## Runtime Expectations
+
+Supported runtime expectations:
+
+- Node.js `>=20`
+- ESM import support
+- package `exports` support
+- standard `fetch` support in the consumer runtime
+
+TypeScript consumer expectation:
+
+- `module=NodeNext`
+- `moduleResolution=NodeNext`
+
+Entrypoint-specific boundary:
+
+- `@echofiles/echo-pdf/local`
+  - intended for local Node/Bun app and CLI use
+  - may depend on Node-only capabilities through the documented local boundary
+- `@echofiles/echo-pdf/worker`
+  - intended for Worker compatibility surfaces
+  - should not be treated as the primary local-first adoption path
+
+## Semver Contract
+
+The semver contract applies to:
+
+- the exported entrypoint paths listed above
+- the exported symbols reachable from those public entrypoints
+- the documented runtime expectations in this file
+
+Semver rules in the current phase:
+
+- breaking changes to public entrypoints or exported symbols require a major release
+- additive exports or backward-compatible parameter expansion may ship in minor or patch releases
+- private implementation files may change without notice
+
+Specific compatibility expectations:
+
+- `@echofiles/echo-pdf` and `@echofiles/echo-pdf/core` remain the documented core API surfaces
+- `@echofiles/echo-pdf/local` remains the documented local document primitive surface
+- `@echofiles/echo-pdf/worker` remains compatibility-only unless the product direction changes explicitly
+
+## Clean Consumer Guarantees
+
+A clean consumer install should be able to:
+
+- install the published package artifact without patching package metadata
+- import each supported public entrypoint directly
+- typecheck NodeNext imports against the published declaration files
+
+The clean-consumer expectation is:
+
+1. install the package into a fresh directory
+2. import:
+   - `@echofiles/echo-pdf`
+   - `@echofiles/echo-pdf/core`
+   - `@echofiles/echo-pdf/local`
+   - `@echofiles/echo-pdf/worker`
+3. observe successful runtime import
+4. observe successful NodeNext typechecking
+
+This is the packaging-level guarantee for downstream adoption.
+
+## Smoke Verification Contract
+
+The repo already carries the corresponding smoke checks:
+
+- `tests/integration/npm-pack-import.integration.test.ts`
+  - verifies fresh import from a packed artifact
+- `tests/integration/ts-nodenext-consumer.integration.test.ts`
+  - verifies a fresh NodeNext consumer typechecks the public imports
+- `npm run test:import-smoke`
+  - the packaged smoke entrypoint used before publishing
+
+These checks are the expected verification path for package-level guarantees.
+
+## What This Contract Does Not Promise
+
+This contract does not promise:
+
+- deep imports into non-exported package paths
+- source-checkout developer workflows through package imports
+- hosted service behavior
+- MCP-first product behavior
+- domain-specific product semantics
+
+Package guarantees are about the published npm artifact and its documented public entrypoints.

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -15,6 +15,8 @@
 
 These are the product surfaces that define the current phase. They carry the primary product and semver expectations.
 
+For the package-level contract, see [`docs/PACKAGING.md`](./PACKAGING.md).
+
 ## Target Users
 
 - developers building local AI agents or IDE integrations that need PDF context


### PR DESCRIPTION
## Summary
- add a dedicated packaging contract doc for the supported public entrypoints
- document runtime expectations, semver guarantees, and clean-consumer import expectations
- link the packaging contract from the README and product positioning docs

## Runtime Boundary
- docs-only change
- no Node / Worker / shared runtime implementation changes

## Validation
- `bun run typecheck`

## Not Run
- unit/integration tests not run because this PR only changes docs and packaging contract language

## Stack
- base PR: #49

Closes #45
