### PR TITLE
feat(cli): align local CLI to six core primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,21 @@
 
 ```bash
 npm i -g @echofiles/echo-pdf
-echo-pdf document index ./sample.pdf
-echo-pdf document structure ./sample.pdf
-echo-pdf document page ./sample.pdf --page 1
-echo-pdf document render ./sample.pdf --page 1
+echo-pdf document ./sample.pdf
+echo-pdf structure ./sample.pdf
+echo-pdf semantic ./sample.pdf
+echo-pdf page ./sample.pdf --page 1
+echo-pdf render ./sample.pdf --page 1
+echo-pdf ocr ./sample.pdf --page 1 --model gpt-4.1-mini
 ```
 
 源码 checkout 的本地开发路径：
 
 ```bash
 npm install
-npm run document:dev -- get ./fixtures/smoke.pdf
+npm run document:dev -- document ./fixtures/smoke.pdf
 npm run document:dev -- structure ./fixtures/smoke.pdf
+npm run document:dev -- semantic ./fixtures/smoke.pdf
 npm run document:dev -- page ./fixtures/smoke.pdf --page 1
 ```
 
@@ -308,48 +311,62 @@ echo-pdf config set --key service.storage.maxFileBytes --value 10000000
 echo-pdf config set --key service.maxPagesPerRequest --value 20
 ```
 
-## 2.1 本地文档索引与读取
+## 2.1 六个核心 primitives
+
+本地 CLI 主命令面与 `@echofiles/echo-pdf/local` 的六个 primitives 一一对应：
+
+- `document <file.pdf>` -> `get_document`
+- `structure <file.pdf>` -> `get_document_structure`
+- `semantic <file.pdf>` -> `get_semantic_document_structure`
+- `page <file.pdf> --page <N>` -> `get_page_content`
+- `render <file.pdf> --page <N>` -> `get_page_render`
+- `ocr <file.pdf> --page <N>` -> `get_page_ocr`
+
+兼容边界：
+
+- 旧的 `document get|index|structure|semantic|page|render|ocr ...` 仍作为兼容别名保留
+- README 和 `--help` 现在优先展示这六个主命令，而不是旧的子命令树
 
 建立本地索引并输出 metadata：
 
 ```bash
-echo-pdf document index ./sample.pdf
-```
-
-读取 document metadata：
-
-```bash
-echo-pdf document get ./sample.pdf
+echo-pdf document ./sample.pdf
 ```
 
 读取结构树：
 
 ```bash
-echo-pdf document structure ./sample.pdf
+echo-pdf structure ./sample.pdf
+```
+
+读取语义结构层：
+
+```bash
+echo-pdf semantic ./sample.pdf
 ```
 
 读取指定页面内容：
 
 ```bash
-echo-pdf document page ./sample.pdf --page 1
+echo-pdf page ./sample.pdf --page 1
 ```
 
 生成页面渲染 artifact：
 
 ```bash
-echo-pdf document render ./sample.pdf --page 1 --scale 2
+echo-pdf render ./sample.pdf --page 1 --scale 2
 ```
 
 生成 OCR artifact（需要本地 provider key / model）：
 
 ```bash
-echo-pdf document ocr ./sample.pdf --page 1 --model gpt-4.1-mini
+echo-pdf ocr ./sample.pdf --page 1 --model gpt-4.1-mini
 ```
 
 自定义 artifact workspace：
 
 ```bash
-echo-pdf document index ./sample.pdf --workspace ./.cache/echo-pdf
+echo-pdf document ./sample.pdf --workspace ./.cache/echo-pdf
 ```
 
 ## 3. MCP 使用（兼容保留，非本阶段重点）

--- a/bin/echo-pdf.js
+++ b/bin/echo-pdf.js
@@ -335,7 +335,7 @@ const loadLocalDocumentApi = async () => {
     }
     throw new Error(
       "Source-checkout document dev mode requires Bun and src/local/index.ts. " +
-      "Use `npm run document:dev -- <subcommand> ...` from a source checkout."
+      "Use `npm run document:dev -- <command> ...` from a source checkout."
     )
   }
   try {
@@ -345,16 +345,112 @@ const loadLocalDocumentApi = async () => {
     if (code === "ERR_MODULE_NOT_FOUND") {
       throw new Error(
         "Local document commands require built artifacts in a source checkout. " +
-        "Run `npm run build` first, use `npm run document:dev -- <subcommand> ...` in a source checkout, or install the published package."
+        "Run `npm run build` first, use `npm run document:dev -- <command> ...` in a source checkout, or install the published package."
       )
     }
     throw error
   }
 }
 
+const LOCAL_PRIMITIVE_COMMANDS = ["document", "structure", "semantic", "page", "render", "ocr"]
+const LEGACY_DOCUMENT_SUBCOMMANDS = ["index", "get", "structure", "semantic", "page", "render", "ocr"]
+
+const isLegacyDocumentSubcommand = (value) => typeof value === "string" && LEGACY_DOCUMENT_SUBCOMMANDS.includes(value)
+
+const readDocumentPrimitiveArgs = (command, subcommand, rest) => {
+  if (command === "document" && isLegacyDocumentSubcommand(subcommand)) {
+    const primitive = subcommand === "index" || subcommand === "get" ? "document" : subcommand
+    return {
+      primitive,
+      pdfPath: rest[0],
+    }
+  }
+  return {
+    primitive: command,
+    pdfPath: command === "document" ? subcommand : rest[0],
+  }
+}
+
+const runLocalPrimitiveCommand = async (command, subcommand, rest, flags) => {
+  const local = await loadLocalDocumentApi()
+  const { primitive, pdfPath } = readDocumentPrimitiveArgs(command, subcommand, rest)
+  const workspaceDir = typeof flags.workspace === "string" ? flags.workspace : undefined
+  const forceRefresh = flags["force-refresh"] === true
+  const renderScale = typeof flags.scale === "string" ? Number(flags.scale) : undefined
+
+  if (typeof pdfPath !== "string" || pdfPath.length === 0 || pdfPath.startsWith("--")) {
+    throw new Error(`${primitive} requires a pdf path argument`)
+  }
+
+  if (primitive === "document") {
+    const data = await local.get_document({ pdfPath, workspaceDir, forceRefresh })
+    print(data)
+    return
+  }
+
+  if (primitive === "structure") {
+    const data = await local.get_document_structure({ pdfPath, workspaceDir, forceRefresh })
+    print(data)
+    return
+  }
+
+  if (primitive === "semantic") {
+    const data = await local.get_semantic_document_structure({
+      pdfPath,
+      workspaceDir,
+      forceRefresh,
+      provider: typeof flags.provider === "string" ? flags.provider : undefined,
+      model: typeof flags.model === "string" ? flags.model : undefined,
+    })
+    print(data)
+    return
+  }
+
+  const pageNumber = typeof flags.page === "string" ? Number(flags.page) : NaN
+  if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new Error(`${primitive} requires --page <positive integer>`)
+  }
+
+  if (primitive === "page") {
+    const data = await local.get_page_content({ pdfPath, workspaceDir, forceRefresh, pageNumber })
+    print(data)
+    return
+  }
+
+  if (primitive === "render") {
+    const data = await local.get_page_render({ pdfPath, workspaceDir, forceRefresh, pageNumber, renderScale })
+    print(data)
+    return
+  }
+
+  if (primitive === "ocr") {
+    const data = await local.get_page_ocr({
+      pdfPath,
+      workspaceDir,
+      forceRefresh,
+      pageNumber,
+      renderScale,
+      provider: typeof flags.provider === "string" ? flags.provider : undefined,
+      model: typeof flags.model === "string" ? flags.model : undefined,
+      prompt: typeof flags.prompt === "string" ? flags.prompt : undefined,
+    })
+    print(data)
+    return
+  }
+
+  throw new Error(`Unsupported local primitive command: ${primitive}`)
+}
+
 const usage = () => {
   process.stdout.write(`echo-pdf CLI\n\n`)
   process.stdout.write(`Commands:\n`)
+  process.stdout.write(`  document <file.pdf> [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  structure <file.pdf> [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  semantic <file.pdf> [--provider alias] [--model model] [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  page <file.pdf> --page <N> [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  render <file.pdf> --page <N> [--scale N] [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  ocr <file.pdf> --page <N> [--scale N] [--provider alias] [--model model] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`\nCompatibility / existing service commands:\n`)
   process.stdout.write(`  init [--service-url URL]\n`)
   process.stdout.write(`  dev [--port 8788] [--host 127.0.0.1]\n`)
   process.stdout.write(`  provider set --provider <${PROVIDER_SET_NAMES.join("|")}> --api-key <KEY> [--profile name]\n`)
@@ -367,9 +463,9 @@ const usage = () => {
   process.stdout.write(`  model list [--profile name]\n`)
   process.stdout.write(`  tools\n`)
   process.stdout.write(`  call --tool <name> --args '<json>' [--provider alias] [--model model] [--profile name] [--auto-upload]\n`)
-  process.stdout.write(`  document index <file.pdf> [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  document get <file.pdf> [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  document structure <file.pdf> [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  document semantic <file.pdf> [--provider alias] [--model model] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  document page <file.pdf> --page <N> [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  document render <file.pdf> --page <N> [--scale N] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  document ocr <file.pdf> --page <N> [--scale N] [--provider alias] [--model model] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
@@ -623,62 +719,9 @@ const main = async () => {
     return
   }
 
-  if (command === "document") {
-    const local = await loadLocalDocumentApi()
-    const pdfPath = rest[0]
-    const workspaceDir = typeof flags.workspace === "string" ? flags.workspace : undefined
-    const forceRefresh = flags["force-refresh"] === true
-    const renderScale = typeof flags.scale === "string" ? Number(flags.scale) : undefined
-    if (typeof pdfPath !== "string" || pdfPath.length === 0) {
-      throw new Error("document command requires a pdf path argument")
-    }
-    if (subcommand === "index" || subcommand === "get") {
-      const data = await local.get_document({ pdfPath, workspaceDir, forceRefresh })
-      print(data)
-      return
-    }
-    if (subcommand === "structure") {
-      const data = await local.get_document_structure({ pdfPath, workspaceDir, forceRefresh })
-      print(data)
-      return
-    }
-    if (subcommand === "page") {
-      const pageNumber = typeof flags.page === "string" ? Number(flags.page) : NaN
-      if (!Number.isInteger(pageNumber) || pageNumber < 1) {
-        throw new Error("document page requires --page <positive integer>")
-      }
-      const data = await local.get_page_content({ pdfPath, workspaceDir, forceRefresh, pageNumber })
-      print(data)
-      return
-    }
-    if (subcommand === "render") {
-      const pageNumber = typeof flags.page === "string" ? Number(flags.page) : NaN
-      if (!Number.isInteger(pageNumber) || pageNumber < 1) {
-        throw new Error("document render requires --page <positive integer>")
-      }
-      const data = await local.get_page_render({ pdfPath, workspaceDir, forceRefresh, pageNumber, renderScale })
-      print(data)
-      return
-    }
-    if (subcommand === "ocr") {
-      const pageNumber = typeof flags.page === "string" ? Number(flags.page) : NaN
-      if (!Number.isInteger(pageNumber) || pageNumber < 1) {
-        throw new Error("document ocr requires --page <positive integer>")
-      }
-      const data = await local.get_page_ocr({
-        pdfPath,
-        workspaceDir,
-        forceRefresh,
-        pageNumber,
-        renderScale,
-        provider: typeof flags.provider === "string" ? flags.provider : undefined,
-        model: typeof flags.model === "string" ? flags.model : undefined,
-        prompt: typeof flags.prompt === "string" ? flags.prompt : undefined,
-      })
-      print(data)
-      return
-    }
-    throw new Error("document command supports: index|get|structure|page|render|ocr")
+  if (LOCAL_PRIMITIVE_COMMANDS.includes(command) || (command === "document" && isLegacyDocumentSubcommand(subcommand))) {
+    await runLocalPrimitiveCommand(command, subcommand, rest, flags)
+    return
   }
 
   if (command === "call") {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check:runtime": "bash ./scripts/check-runtime.sh",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "document:dev": "ECHO_PDF_SOURCE_DEV=1 bun ./bin/echo-pdf.js document",
+    "document:dev": "ECHO_PDF_SOURCE_DEV=1 bun ./bin/echo-pdf.js",
     "typecheck": "npm run check:runtime && tsc --noEmit",
     "test:unit": "npm run check:runtime && vitest run tests/unit",
     "test:import-smoke": "npm run check:runtime && npm run build && vitest run tests/integration/npm-pack-import.integration.test.ts tests/integration/ts-nodenext-consumer.integration.test.ts",

--- a/tests/integration/local-document-cli.integration.test.ts
+++ b/tests/integration/local-document-cli.integration.test.ts
@@ -40,10 +40,10 @@ const runSourceCheckoutDocumentDev = async (repoDir: string, args: string[]): Pr
 }
 
 describe("local document CLI", () => {
-  itWithNode20("indexes and reads a PDF through document commands", async () => {
+  itWithNode20("reads a PDF through the six primitive commands", async () => {
     const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-"))
 
-    const { stdout: docRaw } = await runCli(rootDir, ["document", "get", fixturePdf, "--workspace", workspaceDir])
+    const { stdout: docRaw } = await runCli(rootDir, ["document", fixturePdf, "--workspace", workspaceDir])
     const doc = JSON.parse(docRaw) as {
       documentId: string
       pageCount: number
@@ -55,7 +55,7 @@ describe("local document CLI", () => {
     expect(doc.pageCount).toBeGreaterThan(0)
     expect(doc.cacheStatus).toBe("fresh")
 
-    const { stdout: structureRaw } = await runCli(rootDir, ["document", "structure", fixturePdf, "--workspace", workspaceDir])
+    const { stdout: structureRaw } = await runCli(rootDir, ["structure", fixturePdf, "--workspace", workspaceDir])
     const structure = JSON.parse(structureRaw) as {
       documentId: string
       root: {
@@ -65,7 +65,19 @@ describe("local document CLI", () => {
     expect(structure.documentId).toBe(doc.documentId)
     expect(structure.root.children?.[0]?.pageNumber).toBe(1)
 
-    const { stdout: pageRaw } = await runCli(rootDir, ["document", "page", fixturePdf, "--page", "1", "--workspace", workspaceDir])
+    const { stdout: semanticRaw } = await runCli(rootDir, ["semantic", fixturePdf, "--workspace", workspaceDir])
+    const semantic = JSON.parse(semanticRaw) as {
+      documentId: string
+      pageIndexArtifactPath: string
+      root: {
+        type: string
+      }
+    }
+    expect(semantic.documentId).toBe(doc.documentId)
+    expect(semantic.pageIndexArtifactPath.endsWith("structure.json")).toBe(true)
+    expect(semantic.root.type).toBe("document")
+
+    const { stdout: pageRaw } = await runCli(rootDir, ["page", fixturePdf, "--page", "1", "--workspace", workspaceDir])
     const page = JSON.parse(pageRaw) as {
       documentId: string
       pageNumber: number
@@ -75,7 +87,7 @@ describe("local document CLI", () => {
     expect(page.pageNumber).toBe(1)
     expect(typeof page.text).toBe("string")
 
-    const { stdout: renderRaw } = await runCli(rootDir, ["document", "render", fixturePdf, "--page", "1", "--workspace", workspaceDir])
+    const { stdout: renderRaw } = await runCli(rootDir, ["render", fixturePdf, "--page", "1", "--workspace", workspaceDir])
     const render = JSON.parse(renderRaw) as {
       pageNumber: number
       mimeType: string
@@ -86,13 +98,13 @@ describe("local document CLI", () => {
     expect(render.mimeType).toBe("image/png")
     expect(render.cacheStatus).toBe("fresh")
 
-    const { stdout: docSecondRaw } = await runCli(rootDir, ["document", "get", fixturePdf, "--workspace", workspaceDir])
+    const { stdout: docSecondRaw } = await runCli(rootDir, ["document", fixturePdf, "--workspace", workspaceDir])
     const docSecond = JSON.parse(docSecondRaw) as {
       cacheStatus: "fresh" | "reused"
     }
     expect(docSecond.cacheStatus).toBe("reused")
 
-    const { stdout: renderSecondRaw } = await runCli(rootDir, ["document", "render", fixturePdf, "--page", "1", "--workspace", workspaceDir])
+    const { stdout: renderSecondRaw } = await runCli(rootDir, ["render", fixturePdf, "--page", "1", "--workspace", workspaceDir])
     const renderSecond = JSON.parse(renderSecondRaw) as {
       cacheStatus: "fresh" | "reused"
       imagePath: string
@@ -104,6 +116,22 @@ describe("local document CLI", () => {
       documentId?: string
     }
     expect(stored.documentId).toBe(doc.documentId)
+  })
+
+  itWithNode20("keeps legacy document subcommands as compatibility aliases", async () => {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-legacy-"))
+
+    const { stdout: docRaw } = await runCli(rootDir, ["document", "get", fixturePdf, "--workspace", workspaceDir])
+    const { stdout: structureRaw } = await runCli(rootDir, ["document", "structure", fixturePdf, "--workspace", workspaceDir])
+    const { stdout: semanticRaw } = await runCli(rootDir, ["document", "semantic", fixturePdf, "--workspace", workspaceDir])
+    const { stdout: pageRaw } = await runCli(rootDir, ["document", "page", fixturePdf, "--page", "1", "--workspace", workspaceDir])
+    const { stdout: renderRaw } = await runCli(rootDir, ["document", "render", fixturePdf, "--page", "1", "--workspace", workspaceDir])
+
+    expect(JSON.parse(docRaw).documentId).toBeTruthy()
+    expect(JSON.parse(structureRaw).root.type).toBe("document")
+    expect(JSON.parse(semanticRaw).root.type).toBe("document")
+    expect(JSON.parse(pageRaw).pageNumber).toBe(1)
+    expect(JSON.parse(renderRaw).mimeType).toBe("image/png")
   })
 
   itWithNode20AndBun("supports a source-checkout document workflow even when dist artifacts exist", async () => {
@@ -120,7 +148,7 @@ describe("local document CLI", () => {
       "utf-8"
     )
 
-    const { stdout } = await runSourceCheckoutDocumentDev(checkoutDir, ["get", fixturePdf, "--workspace", checkoutDir])
+    const { stdout } = await runSourceCheckoutDocumentDev(checkoutDir, ["document", fixturePdf, "--workspace", checkoutDir])
     const doc = JSON.parse(stdout.replace(/^>.*\n/gm, "").trim()) as {
       pageCount: number
       cacheStatus: "fresh" | "reused"


### PR DESCRIPTION
## Summary
- align the local CLI around the six core local document primitives
- make `--help` and README present the local-first command surface as:
  - `document <file.pdf>` -> `get_document`
  - `structure <file.pdf>` -> `get_document_structure`
  - `semantic <file.pdf>` -> `get_semantic_document_structure`
  - `page <file.pdf> --page <N>` -> `get_page_content`
  - `render <file.pdf> --page <N>` -> `get_page_render`
  - `ocr <file.pdf> --page <N>` -> `get_page_ocr`
- keep legacy `document get|index|structure|semantic|page|render|ocr ...` commands as compatibility aliases instead of removing them outright
- update the source-checkout `document:dev` flow so it runs the same top-level local primitive commands

## Runtime Boundary
- Node-only CLI surface
- no Worker runtime changes
- no MCP or hosted-service behavior changes

## Compatibility / Change Boundary
- new documented local-first command surface is the six primitive commands above
- existing `document ...` subcommands remain supported as compatibility aliases
- existing service/MCP-related commands remain present but are not expanded or reworked in this PR

## Validation
- `bun run build`
- `test -f dist/local/index.js`
- `bun run typecheck`
- `bun run test:unit`
- `bunx vitest run tests/integration/local-document-cli.integration.test.ts`
- `bunx vitest run tests/integration/npm-pack-import.integration.test.ts tests/integration/ts-nodenext-consumer.integration.test.ts --testTimeout=400000`
- `node bin/echo-pdf.js --help`

## Not Covered
- real OCR CLI execution with provider credentials was not exercised in this PR because that path is env-gated
- docs site work is intentionally out of scope
- MCP / SaaS / domain-specific logic is intentionally untouched

Closes #46
