### PR TITLE
docs(site): add static local-first documentation site

### DIFF
--- a/site/api/index.html
+++ b/site/api/index.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>API Reference | echo-pdf Docs</title>
+    <link rel="stylesheet" href="../assets/styles.css">
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="../index.html"><span class="brand-mark">EP</span><span>echo-pdf docs</span></a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../index.html">Overview</a>
+          <a href="./index.html" aria-current="page">API</a>
+          <a href="../cli/index.html">CLI</a>
+          <a href="../concepts/page-index.html">Concepts</a>
+          <a href="../integrations/index.html">Integrations</a>
+        </nav>
+      </header>
+      <main>
+        <section class="hero">
+          <span class="eyebrow">API</span>
+          <h1>Six local primitives, one product surface.</h1>
+          <p class="lead">
+            The local package API is intentionally small. These six primitives are the core surface that downstream local agents and apps should build around.
+          </p>
+        </section>
+
+        <section class="table-wrap" style="margin-top:28px;">
+          <table>
+            <thead>
+              <tr><th>Primitive</th><th>Returns</th><th>Writes</th><th>Primary use</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>get_document</code></td><td>document metadata</td><td><code>document.json</code></td><td>source snapshot and document root</td></tr>
+              <tr><td><code>get_document_structure</code></td><td>stable page index</td><td><code>structure.json</code></td><td>iterate pages and locate page artifacts</td></tr>
+              <tr><td><code>get_semantic_document_structure</code></td><td>heading / section tree</td><td><code>semantic-structure.json</code></td><td>chapter navigation without mutating <code>pages[]</code></td></tr>
+              <tr><td><code>get_page_content</code></td><td>page text artifact</td><td><code>pages/&lt;page&gt;.json</code></td><td>page retrieval and semantic input</td></tr>
+              <tr><td><code>get_page_render</code></td><td>render metadata</td><td><code>renders/&lt;page&gt;.json</code> + PNG</td><td>visual page reuse</td></tr>
+              <tr><td><code>get_page_ocr</code></td><td>OCR metadata</td><td><code>ocr/&lt;page&gt;.json</code></td><td>text recovery over rendered image input</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="two-col" style="margin-top:28px;">
+          <article class="panel">
+            <h2>Import surface</h2>
+            <pre><code>import {
+  get_document,
+  get_document_structure,
+  get_semantic_document_structure,
+  get_page_content,
+  get_page_render,
+  get_page_ocr,
+} from "@echofiles/echo-pdf/local"</code></pre>
+          </article>
+          <article class="panel">
+            <h2>Runtime expectation</h2>
+            <ul>
+              <li>Node.js <code>&gt;=20</code></li>
+              <li>ESM import support</li>
+              <li>local-first Node/Bun runtime</li>
+              <li>package <code>exports</code> aware consumer</li>
+            </ul>
+          </article>
+        </section>
+
+        <section class="callout warn" style="margin-top:32px;">
+          <h3>Not the place for broad tool sprawl.</h3>
+          <p>
+            This reference is intentionally centered on six core primitives. Compatibility surfaces may remain elsewhere in the repo, but they are not the main API story of the local-first product.
+          </p>
+        </section>
+      </main>
+      <footer class="footer"><div class="footer-grid"><div><p class="kicker">Next</p><ul><li><a href="../cli/index.html">Map the same surface to CLI</a></li><li><a href="../integrations/index.html">See downstream integration guidance</a></li></ul></div><div><p class="kicker">Package contract</p><p>Public entrypoints and semver expectations are documented in <code>docs/PACKAGING.md</code>.</p></div></div></footer>
+    </div>
+  </body>
+</html>

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,0 +1,378 @@
+:root {
+  --bg: #f4efe4;
+  --bg-soft: #fbf7f0;
+  --paper: rgba(255, 252, 247, 0.82);
+  --text: #17231e;
+  --muted: #52635c;
+  --line: rgba(23, 35, 30, 0.12);
+  --accent: #0f766e;
+  --accent-strong: #0d5f58;
+  --accent-soft: rgba(15, 118, 110, 0.12);
+  --warn: #b45309;
+  --shadow: 0 24px 80px rgba(23, 35, 30, 0.12);
+  --radius: 24px;
+  --radius-sm: 16px;
+  --content: 1120px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  color: var(--text);
+  font-family: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(15, 118, 110, 0.16), transparent 32%),
+    radial-gradient(circle at top right, rgba(180, 83, 9, 0.12), transparent 28%),
+    linear-gradient(180deg, #f8f2e8 0%, #f3ecdf 46%, #efe6d8 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(23, 35, 30, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(23, 35, 30, 0.04) 1px, transparent 1px);
+  background-size: 36px 36px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.7), transparent 80%);
+}
+
+.site-shell {
+  position: relative;
+  max-width: var(--content);
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 24px;
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 252, 247, 0.7);
+  backdrop-filter: blur(14px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.brand-mark {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  color: white;
+  background: linear-gradient(135deg, var(--accent), #12493f);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24);
+}
+
+.topnav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.topnav a,
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  color: var(--text);
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid transparent;
+}
+
+.topnav a:hover,
+.topnav a[aria-current="page"] {
+  border-color: var(--line);
+  background: white;
+}
+
+.hero,
+.panel,
+.callout,
+.card,
+.table-wrap,
+.footer {
+  border: 1px solid var(--line);
+  background: var(--paper);
+  backdrop-filter: blur(14px);
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  padding: 44px;
+  border-radius: calc(var(--radius) + 8px);
+  overflow: hidden;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hero-grid,
+.two-col,
+.cards,
+.metrics,
+.info-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.hero-grid {
+  grid-template-columns: 1.35fr 0.9fr;
+  align-items: start;
+  margin-top: 18px;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 14px;
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, serif;
+  font-weight: 700;
+  line-height: 1.04;
+}
+
+h1 {
+  font-size: clamp(2.8rem, 6vw, 5rem);
+}
+
+h2 {
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  margin-top: 36px;
+}
+
+h3 {
+  font-size: 1.3rem;
+}
+
+p,
+li {
+  color: var(--muted);
+  line-height: 1.68;
+  font-size: 1.02rem;
+}
+
+.lead {
+  font-size: 1.16rem;
+  max-width: 52rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 26px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 18px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  text-decoration: none;
+  color: var(--text);
+  background: white;
+  font-weight: 600;
+}
+
+.button.primary {
+  color: white;
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--accent), #12493f);
+}
+
+.metrics {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.metric,
+.card,
+.panel,
+.callout,
+.footer {
+  border-radius: var(--radius);
+}
+
+.metric,
+.card,
+.panel,
+.callout {
+  padding: 22px;
+}
+
+.metric strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 1.9rem;
+  font-family: "Iowan Old Style", "Palatino Linotype", serif;
+}
+
+.two-col {
+  grid-template-columns: 0.92fr 1.08fr;
+  margin-top: 26px;
+}
+
+.cards,
+.info-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.card ul,
+.panel ul,
+.callout ul,
+.footer ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.card code,
+.panel code,
+.callout code,
+.table-wrap code,
+.hero code,
+pre code,
+p code,
+li code {
+  font-family: "SFMono-Regular", "JetBrains Mono", "Cascadia Code", monospace;
+  font-size: 0.94em;
+  padding: 0.18em 0.36em;
+  border-radius: 6px;
+  background: rgba(23, 35, 30, 0.06);
+  color: var(--text);
+}
+
+pre {
+  margin: 0;
+  overflow-x: auto;
+  padding: 18px;
+  border-radius: 18px;
+  background: #16201d;
+  color: #ebf4ef;
+}
+
+pre code {
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.section-label {
+  margin-top: 52px;
+  margin-bottom: 14px;
+  color: var(--accent-strong);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.86rem;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  padding: 8px;
+}
+
+.table-wrap table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table-wrap th,
+.table-wrap td {
+  padding: 14px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+  vertical-align: top;
+}
+
+.table-wrap th {
+  color: var(--accent-strong);
+  font-size: 0.92rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.callout.warn {
+  border-color: rgba(180, 83, 9, 0.25);
+  background: rgba(255, 247, 237, 0.82);
+}
+
+.callout.warn h3 {
+  color: var(--warn);
+}
+
+.footer {
+  margin-top: 48px;
+  padding: 24px;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 18px;
+}
+
+.kicker {
+  color: var(--accent-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.84rem;
+}
+
+@media (max-width: 960px) {
+  .hero-grid,
+  .two-col,
+  .cards,
+  .metrics,
+  .info-grid,
+  .footer-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    border-radius: 28px;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .hero {
+    padding: 28px;
+  }
+}

--- a/site/cli/index.html
+++ b/site/cli/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CLI Reference | echo-pdf Docs</title>
+    <link rel="stylesheet" href="../assets/styles.css">
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="../index.html"><span class="brand-mark">EP</span><span>echo-pdf docs</span></a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../index.html">Overview</a>
+          <a href="../api/index.html">API</a>
+          <a href="./index.html" aria-current="page">CLI</a>
+          <a href="../concepts/page-index.html">Concepts</a>
+          <a href="../integrations/index.html">Integrations</a>
+        </nav>
+      </header>
+      <main>
+        <section class="hero">
+          <span class="eyebrow">CLI</span>
+          <h1>One command surface, same six primitives.</h1>
+          <p class="lead">
+            The local CLI is aligned to the same six primitives as the package API. Use top-level commands for the mainline workflow; legacy aliases may remain for compatibility.
+          </p>
+        </section>
+
+        <section class="panel" style="margin-top:28px;">
+          <h2>Primary command mapping</h2>
+          <pre><code>echo-pdf document ./sample.pdf
+echo-pdf structure ./sample.pdf
+echo-pdf semantic ./sample.pdf
+echo-pdf page ./sample.pdf --page 1
+echo-pdf render ./sample.pdf --page 1
+echo-pdf ocr ./sample.pdf --page 1 --model gpt-4.1-mini</code></pre>
+        </section>
+
+        <section class="two-col" style="margin-top:28px;">
+          <article class="panel">
+            <h2>Source checkout workflow</h2>
+            <pre><code>npm install
+npm run document:dev -- document ./fixtures/smoke.pdf
+npm run document:dev -- structure ./fixtures/smoke.pdf
+npm run document:dev -- semantic ./fixtures/smoke.pdf
+npm run document:dev -- page ./fixtures/smoke.pdf --page 1</code></pre>
+          </article>
+          <article class="panel">
+            <h2>What stays out of the way</h2>
+            <ul>
+              <li>no docs-site service backend</li>
+              <li>no MCP-first framing on this page</li>
+              <li>no hosted dashboards or remote playgrounds</li>
+              <li>no domain-specific command families</li>
+            </ul>
+          </article>
+        </section>
+
+        <section class="callout warn" style="margin-top:32px;">
+          <h3>This is still a local component CLI.</h3>
+          <p>
+            Service and MCP commands may exist for compatibility, but this reference intentionally centers the local-first CLI workflow that writes workspace artifacts on the current machine.
+          </p>
+        </section>
+      </main>
+      <footer class="footer"><div class="footer-grid"><div><p class="kicker">Next</p><ul><li><a href="../api/index.html">Package API</a></li><li><a href="../concepts/workspace-artifacts.html">Workspace artifact model</a></li></ul></div><div><p class="kicker">Boundary</p><p>The docs site describes CLI usage. It does not expose a remote execution surface.</p></div></div></footer>
+    </div>
+  </body>
+</html>

--- a/site/concepts/page-index.html
+++ b/site/concepts/page-index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Page Index | echo-pdf Docs</title>
+    <link rel="stylesheet" href="../assets/styles.css">
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="../index.html"><span class="brand-mark">EP</span><span>echo-pdf docs</span></a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../index.html">Overview</a>
+          <a href="../api/index.html">API</a>
+          <a href="../cli/index.html">CLI</a>
+          <a href="./page-index.html" aria-current="page">Concepts</a>
+          <a href="../integrations/index.html">Integrations</a>
+        </nav>
+      </header>
+      <main>
+        <section class="hero">
+          <span class="eyebrow">Concept</span>
+          <h1>Page index stays stable.</h1>
+          <p class="lead">
+            <code>get_document_structure()</code> is the stable page-index contract. It returns <code>document -&gt; pages[]</code>
+            and does not silently absorb semantic hierarchy.
+          </p>
+        </section>
+
+        <section class="two-col">
+          <article class="panel">
+            <h2>Why it exists</h2>
+            <ul>
+              <li>iterate pages deterministically</li>
+              <li>locate per-page artifacts under one document root</li>
+              <li>support downstream incremental reads without semantic assumptions</li>
+            </ul>
+          </article>
+          <article class="panel">
+            <h2>Artifact mapping</h2>
+            <pre><code>documents/&lt;documentId&gt;/
+  document.json
+  structure.json
+  pages/
+    0001.json
+    0002.json</code></pre>
+          </article>
+        </section>
+
+        <p class="section-label">Stable contract</p>
+        <section class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>Artifact</th><th>Purpose</th><th>Safe downstream assumption</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>document.json</code></td><td>source metadata</td><td>tracks source path, snapshot, page count, artifact roots</td></tr>
+              <tr><td><code>structure.json</code></td><td>page index</td><td><code>root.children</code> stays a page list, not a semantic tree</td></tr>
+              <tr><td><code>pages/0001.json</code></td><td>page content</td><td>contains page text, preview, and artifact path</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="callout warn" style="margin-top:32px;">
+          <h3>No hidden promotion to semantics.</h3>
+          <p>
+            If you need headings or sections, use the semantic layer explicitly. The page index is intentionally flatter and more boring,
+            because downstream tooling depends on it being mechanically stable.
+          </p>
+        </section>
+      </main>
+      <footer class="footer"><div class="footer-grid"><div><p class="kicker">Next</p><ul><li><a href="./semantic-structure.html">Semantic structure layer</a></li><li><a href="./workspace-artifacts.html">Workspace artifacts</a></li></ul></div><div><p class="kicker">Local-first rule</p><p>This page documents artifacts written to the local workspace. It does not imply hosted processing.</p></div></div></footer>
+    </div>
+  </body>
+</html>

--- a/site/concepts/semantic-structure.html
+++ b/site/concepts/semantic-structure.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Semantic Structure | echo-pdf Docs</title>
+    <link rel="stylesheet" href="../assets/styles.css">
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="../index.html"><span class="brand-mark">EP</span><span>echo-pdf docs</span></a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../index.html">Overview</a>
+          <a href="../api/index.html">API</a>
+          <a href="../cli/index.html">CLI</a>
+          <a href="./semantic-structure.html" aria-current="page">Concepts</a>
+          <a href="../integrations/index.html">Integrations</a>
+        </nav>
+      </header>
+      <main>
+        <section class="hero">
+          <span class="eyebrow">Concept</span>
+          <h1>Semantic structure is a separate layer.</h1>
+          <p class="lead">
+            <code>get_semantic_document_structure()</code> writes <code>semantic-structure.json</code> alongside the page index.
+            It adds heading and section structure without changing the shape of <code>pages[]</code>.
+          </p>
+        </section>
+        <section class="cards">
+          <article class="card">
+            <h3>Primary path</h3>
+            <p>Agent-first extraction using local provider/model configuration.</p>
+            <p><code>detector = agent-structured-v1</code></p>
+          </article>
+          <article class="card">
+            <h3>Fallback path</h3>
+            <p>Conservative heuristic fallback when no model is configured or extraction fails.</p>
+            <p><code>detector = heading-heuristic-v1</code></p>
+          </article>
+          <article class="card">
+            <h3>Downstream rule</h3>
+            <p>Read detector and strategy metadata before assuming semantic richness or cache reuse.</p>
+          </article>
+        </section>
+
+        <p class="section-label">Metadata that matters</p>
+        <section class="table-wrap">
+          <table>
+            <thead>
+              <tr><th>Field</th><th>Why it exists</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>detector</code></td><td>identifies which semantic extraction path produced the artifact</td></tr>
+              <tr><td><code>strategyKey</code></td><td>changes when provider, model, or extraction budget changes enough to invalidate reuse</td></tr>
+              <tr><td><code>pageIndexArtifactPath</code></td><td>links the semantic layer back to the stable page index</td></tr>
+              <tr><td><code>pageArtifactPath</code></td><td>lets section nodes point back to the originating page artifact</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="callout warn" style="margin-top:32px;">
+          <h3>Still not domain logic.</h3>
+          <p>
+            The semantic layer is general document structure. It should not encode datasheet-specific, EDA-specific, or other downstream product semantics.
+          </p>
+        </section>
+      </main>
+      <footer class="footer"><div class="footer-grid"><div><p class="kicker">Next</p><ul><li><a href="./page-index.html">Page index</a></li><li><a href="./workspace-artifacts.html">Workspace artifacts</a></li></ul></div><div><p class="kicker">Boundary</p><p>Semantics are local-first and artifact-backed. This page is docs-only and does not imply any remote extraction service.</p></div></div></footer>
+    </div>
+  </body>
+</html>

--- a/site/concepts/workspace-artifacts.html
+++ b/site/concepts/workspace-artifacts.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Workspace Artifacts | echo-pdf Docs</title>
+    <link rel="stylesheet" href="../assets/styles.css">
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="../index.html"><span class="brand-mark">EP</span><span>echo-pdf docs</span></a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../index.html">Overview</a>
+          <a href="../api/index.html">API</a>
+          <a href="../cli/index.html">CLI</a>
+          <a href="./workspace-artifacts.html" aria-current="page">Concepts</a>
+          <a href="../integrations/index.html">Integrations</a>
+        </nav>
+      </header>
+      <main>
+        <section class="hero">
+          <span class="eyebrow">Concept</span>
+          <h1>Workspace artifacts are part of the product surface.</h1>
+          <p class="lead">
+            <code>.echo-pdf-workspace/</code> is not incidental cache dust. It is an inspectable local contract for downstream tools that need document, page, render, OCR, and semantic artifacts.
+          </p>
+        </section>
+
+        <section class="panel">
+          <h2>Directory layout</h2>
+          <pre><code>.echo-pdf-workspace/
+  documents/&lt;documentId&gt;/
+    document.json
+    structure.json
+    semantic-structure.json
+    pages/
+      0001.json
+    renders/
+      0001.scale-2.json
+      0001.scale-2.png
+    ocr/
+      0001.scale-2.provider-openai.model-gpt-4o.prompt-&lt;hash&gt;.json</code></pre>
+        </section>
+
+        <section class="info-grid" style="margin-top:26px;">
+          <article class="card">
+            <h3>Reuse boundary</h3>
+            <p>Artifacts reuse only when source snapshot and strategy metadata still match the current document state.</p>
+          </article>
+          <article class="card">
+            <h3>Traceability</h3>
+            <p>Artifacts link back to source files, sibling artifacts, and page-level origins so downstream readers can audit what they consume.</p>
+          </article>
+          <article class="card">
+            <h3>What not to assume</h3>
+            <p><code>documentId</code> is path-derived, not a portable content hash. Optional artifacts appear only after their primitive runs.</p>
+          </article>
+        </section>
+
+        <section class="callout warn" style="margin-top:32px;">
+          <h3>Local artifact contract, not remote storage.</h3>
+          <p>
+            The workspace is documented as a local filesystem contract. This site does not promise a hosted artifact browser or cloud artifact retention surface.
+          </p>
+        </section>
+      </main>
+      <footer class="footer"><div class="footer-grid"><div><p class="kicker">Continue</p><ul><li><a href="../integrations/index.html">How downstream apps should consume artifacts</a></li><li><a href="../api/index.html">Primitive reference</a></li></ul></div><div><p class="kicker">Spec source</p><p>Detailed requirements live in <code>docs/WORKSPACE_CONTRACT.md</code>.</p></div></div></footer>
+    </div>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>echo-pdf Docs</title>
+    <meta name="description" content="Static docs for echo-pdf, a local-first PDF context engine for AI agents.">
+    <link rel="stylesheet" href="./assets/styles.css">
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="./index.html">
+          <span class="brand-mark">EP</span>
+          <span>echo-pdf docs</span>
+        </a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="./index.html" aria-current="page">Overview</a>
+          <a href="./api/index.html">API</a>
+          <a href="./cli/index.html">CLI</a>
+          <a href="./concepts/page-index.html">Concepts</a>
+          <a href="./integrations/index.html">Integrations</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="hero">
+          <span class="eyebrow">Docs only, not a service</span>
+          <div class="hero-grid">
+            <div>
+              <h1>Local-first PDF context for agents.</h1>
+              <p class="lead">
+                <code>echo-pdf</code> turns local PDFs into reusable package APIs, CLI outputs, and workspace artifacts.
+                This site explains the product boundary and local workflows. It does not expose hosted PDF processing.
+              </p>
+              <div class="actions">
+                <a class="button primary" href="./cli/index.html">Start with the CLI</a>
+                <a class="button" href="./api/index.html">Read the 6 primitives</a>
+                <a class="button" href="./integrations/index.html">Integration contract</a>
+              </div>
+            </div>
+            <div class="panel">
+              <p class="kicker">Primary surfaces</p>
+              <ul>
+                <li><code>@echofiles/echo-pdf</code> npm package</li>
+                <li><code>echo-pdf</code> local CLI</li>
+                <li><code>.echo-pdf-workspace/</code> inspectable artifacts</li>
+                <li>static docs site for install and contracts</li>
+              </ul>
+              <p class="kicker" style="margin-top:20px;">Non-goals in this phase</p>
+              <ul>
+                <li>hosted SaaS or multi-tenant platform work</li>
+                <li>treating MCP as the main entrypoint</li>
+                <li>turning the site into an online playground</li>
+                <li>datasheet / EDA or other domain-specific logic</li>
+              </ul>
+            </div>
+          </div>
+          <div class="metrics">
+            <div class="metric card">
+              <strong>6</strong>
+              <p>core document primitives, mirrored by the local CLI and package API.</p>
+            </div>
+            <div class="metric card">
+              <strong>3</strong>
+              <p>main product surfaces: package, CLI, workspace artifacts.</p>
+            </div>
+            <div class="metric card">
+              <strong>0</strong>
+              <p>hosted promises. This site documents a local product, not a remote service.</p>
+            </div>
+          </div>
+        </section>
+
+        <p class="section-label">Quickstart</p>
+        <section class="two-col">
+          <div class="panel">
+            <h2>Install and run locally</h2>
+            <pre><code>npm i -g @echofiles/echo-pdf
+
+echo-pdf document ./sample.pdf
+echo-pdf structure ./sample.pdf
+echo-pdf semantic ./sample.pdf
+echo-pdf page ./sample.pdf --page 1
+echo-pdf render ./sample.pdf --page 1
+echo-pdf ocr ./sample.pdf --page 1 --model gpt-4.1-mini</code></pre>
+          </div>
+          <div class="panel">
+            <h2>What the local run gives you</h2>
+            <ul>
+              <li>stable page index via <code>structure.json</code></li>
+              <li>optional semantic layer via <code>semantic-structure.json</code></li>
+              <li>page JSON, render PNG, and OCR JSON artifacts under one workspace root</li>
+              <li>cache reuse keyed by source snapshot and strategy metadata</li>
+            </ul>
+          </div>
+        </section>
+
+        <p class="section-label">Information architecture</p>
+        <section class="cards">
+          <article class="card">
+            <h3>Concepts</h3>
+            <p>Understand the page index, semantic structure layer, and workspace artifact contract.</p>
+            <div class="actions">
+              <a class="button" href="./concepts/page-index.html">Page index</a>
+              <a class="button" href="./concepts/semantic-structure.html">Semantic structure</a>
+              <a class="button" href="./concepts/workspace-artifacts.html">Workspace artifacts</a>
+            </div>
+          </article>
+          <article class="card">
+            <h3>API</h3>
+            <p>Read the six local-first primitives and how they map to the artifact model.</p>
+            <div class="actions">
+              <a class="button" href="./api/index.html">API reference</a>
+            </div>
+          </article>
+          <article class="card">
+            <h3>CLI</h3>
+            <p>Use the same six primitives from the command line, with a clear source-checkout workflow.</p>
+            <div class="actions">
+              <a class="button" href="./cli/index.html">CLI reference</a>
+            </div>
+          </article>
+        </section>
+
+        <p class="section-label">Product boundary</p>
+        <section class="info-grid">
+          <article class="card">
+            <h3>What this site is for</h3>
+            <p>Explain install, contracts, local-first workflows, and the shape of the public product.</p>
+          </article>
+          <article class="card">
+            <h3>What this site is not</h3>
+            <p>An online PDF processor, hosted dashboard, account surface, or remote API playground.</p>
+          </article>
+          <article class="card">
+            <h3>How downstream products should read it</h3>
+            <p>Use it as the docs layer for a local component. Build product-specific logic outside <code>echo-pdf</code>.</p>
+          </article>
+        </section>
+
+        <section class="callout warn" style="margin-top:32px;">
+          <h3>Compatibility surfaces are secondary.</h3>
+          <p>
+            Worker and MCP surfaces may still exist in the repo for compatibility, but they are not the main adoption path in this phase.
+            The homepage, concepts, API, and CLI sections intentionally keep the center of gravity on local package + CLI + artifacts.
+          </p>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="kicker">Continue reading</p>
+            <ul>
+              <li><a href="./api/index.html">Six primitive API reference</a></li>
+              <li><a href="./cli/index.html">CLI command mapping</a></li>
+              <li><a href="./integrations/index.html">Integration guidance for local downstream apps</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="kicker">Repository docs</p>
+            <ul>
+              <li><code>docs/PRODUCT.md</code></li>
+              <li><code>docs/PACKAGING.md</code></li>
+              <li><code>docs/WORKSPACE_CONTRACT.md</code></li>
+            </ul>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/site/integrations/index.html
+++ b/site/integrations/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Integrations | echo-pdf Docs</title>
+    <link rel="stylesheet" href="../assets/styles.css">
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="../index.html"><span class="brand-mark">EP</span><span>echo-pdf docs</span></a>
+        <nav class="topnav" aria-label="Primary">
+          <a href="../index.html">Overview</a>
+          <a href="../api/index.html">API</a>
+          <a href="../cli/index.html">CLI</a>
+          <a href="../concepts/page-index.html">Concepts</a>
+          <a href="./index.html" aria-current="page">Integrations</a>
+        </nav>
+      </header>
+      <main>
+        <section class="hero">
+          <span class="eyebrow">Integrations</span>
+          <h1>Use echo-pdf as a local document component.</h1>
+          <p class="lead">
+            Downstream products should treat <code>echo-pdf</code> as a general local PDF component that produces package APIs, CLI outputs, and workspace artifacts.
+            Product-specific policy belongs outside this repo.
+          </p>
+        </section>
+
+        <section class="cards" style="margin-top:28px;">
+          <article class="card">
+            <h3>Recommended adoption path</h3>
+            <ul>
+              <li>install the npm package</li>
+              <li>use the six local primitives or aligned CLI commands</li>
+              <li>consume artifacts from the local workspace</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>What downstream code may rely on</h3>
+            <ul>
+              <li>public package entrypoints</li>
+              <li>stable page index contract</li>
+              <li>workspace artifact layout and traceability metadata</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>What downstream code should not assume</h3>
+            <ul>
+              <li>deep imports into internals</li>
+              <li>hosted service behavior</li>
+              <li>MCP as the product center of gravity</li>
+            </ul>
+          </article>
+        </section>
+
+        <section class="panel" style="margin-top:28px;">
+          <h2>Local integration shape</h2>
+          <pre><code>local PDF
+  -> echo-pdf package / CLI
+  -> .echo-pdf-workspace artifacts
+  -> downstream local app or agent
+  -> product-specific logic outside echo-pdf</code></pre>
+        </section>
+
+        <section class="callout warn" style="margin-top:32px;">
+          <h3>No hosted implication.</h3>
+          <p>
+            This integration guidance is intentionally local-first. The docs site is not advertising a hosted API, managed tenancy, or browser-side PDF processing service.
+          </p>
+        </section>
+      </main>
+      <footer class="footer"><div class="footer-grid"><div><p class="kicker">Related docs</p><ul><li><a href="../concepts/workspace-artifacts.html">Workspace artifact contract</a></li><li><a href="../api/index.html">Primitive API reference</a></li><li><a href="../cli/index.html">CLI workflows</a></li></ul></div><div><p class="kicker">Product boundary</p><p><code>echo-pdf</code> stays a general document component. Downstream domain logic belongs elsewhere.</p></div></div></footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dependency-free static docs site under `site/`
- keep the site explicitly documentation-only, not a hosted product surface
- center the site on the current product positioning: local-first PDF context for agents via npm package + CLI + workspace artifacts

## Information Architecture
- `site/index.html`
  - homepage with product positioning, quickstart, primary surfaces, and non-goals
- `site/concepts/page-index.html`
  - stable page-index contract
- `site/concepts/semantic-structure.html`
  - separate semantic layer and detector/strategy metadata
- `site/concepts/workspace-artifacts.html`
  - workspace artifact contract and local cache boundary
- `site/api/index.html`
  - six core primitives as the main API surface
- `site/cli/index.html`
  - local CLI workflows aligned to the same six primitives
- `site/integrations/index.html`
  - downstream local integration guidance and product boundary
- `site/assets/styles.css`
  - shared static styling only

## Boundary
- docs-only change
- no product/runtime implementation changes
- no hosted SaaS behavior
- no MCP-first framing
- no domain-specific logic

## Validation
- internal relative-link sanity check across all HTML files
- wording sanity check to confirm the site does not imply hosted service behavior or MCP-as-primary

## Not Covered
- no build system or deployment wiring was added for the docs site in this PR
- no screenshots or browser-based visual QA were captured
- no product implementation changes were made outside `site/`

Closes #44
