### PR TITLE
docs(site): add agent-friendly discovery and homepage proof

### DIFF
--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -146,7 +146,9 @@ body::before {
 .two-col,
 .cards,
 .metrics,
-.info-grid {
+.info-grid,
+.example-grid,
+.proof-grid {
   display: grid;
   gap: 20px;
 }
@@ -253,6 +255,53 @@ li {
 .cards,
 .info-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.example-grid {
+  grid-template-columns: 0.95fr 1.05fr;
+  margin-top: 26px;
+}
+
+.proof-grid {
+  grid-template-columns: 1.15fr 0.85fr;
+  margin-top: 26px;
+}
+
+.artifact-tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.artifact-tree li {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(15, 118, 110, 0.08);
+  border: 1px solid rgba(15, 118, 110, 0.12);
+}
+
+.artifact-tree li span {
+  display: block;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.proof-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.proof-card::after {
+  content: "";
+  position: absolute;
+  inset: auto -40px -60px auto;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(180, 83, 9, 0.18), transparent 68%);
 }
 
 .card ul,
@@ -371,6 +420,8 @@ pre code {
   .cards,
   .metrics,
   .info-grid,
+  .example-grid,
+  .proof-grid,
   .footer-grid {
     grid-template-columns: 1fr;
   }

--- a/site/index.html
+++ b/site/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>echo-pdf Docs</title>
     <meta name="description" content="Static docs for echo-pdf, a local-first PDF context engine for AI agents.">
+    <meta property="og:title" content="echo-pdf Docs | Local-first PDF context for agents">
+    <meta property="og:description" content="Install echo-pdf as a local package + CLI, generate workspace artifacts, and give agents stable PDF context without a hosted service.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://pdf.echofile.ai/">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="echo-pdf Docs | Local-first PDF context for agents">
+    <meta name="twitter:description" content="Docs-only site for the local-first echo-pdf package, CLI, and workspace artifact contract.">
     <link rel="stylesheet" href="./assets/styles.css">
   </head>
   <body>
@@ -40,12 +47,12 @@
               </div>
             </div>
             <div class="panel">
-              <p class="kicker">Primary surfaces</p>
+              <p class="kicker">What an agent gets back</p>
               <ul>
-                <li><code>@echofiles/echo-pdf</code> npm package</li>
-                <li><code>echo-pdf</code> local CLI</li>
-                <li><code>.echo-pdf-workspace/</code> inspectable artifacts</li>
-                <li>static docs site for install and contracts</li>
+                <li><code>document.json</code> with source snapshot and page count</li>
+                <li><code>structure.json</code> with a stable <code>document -&gt; pages[]</code> index</li>
+                <li><code>semantic-structure.json</code> when semantic extraction is requested</li>
+                <li>page JSON, render PNG, and OCR JSON artifacts under one workspace root</li>
               </ul>
               <p class="kicker" style="margin-top:20px;">Non-goals in this phase</p>
               <ul>
@@ -72,10 +79,10 @@
           </div>
         </section>
 
-        <p class="section-label">Quickstart</p>
-        <section class="two-col">
+        <p class="section-label">Agent-first happy path</p>
+        <section class="example-grid">
           <div class="panel">
-            <h2>Install and run locally</h2>
+            <h2>Minimal local run</h2>
             <pre><code>npm i -g @echofiles/echo-pdf
 
 echo-pdf document ./sample.pdf
@@ -86,12 +93,40 @@ echo-pdf render ./sample.pdf --page 1
 echo-pdf ocr ./sample.pdf --page 1 --model gpt-4.1-mini</code></pre>
           </div>
           <div class="panel">
-            <h2>What the local run gives you</h2>
+            <h2>Copyable output example</h2>
+            <pre><code>{
+  "documentId": "b1d2f6a8e9c4f013",
+  "artifactPaths": {
+    "documentJsonPath": ".echo-pdf-workspace/documents/b1d2f6a8e9c4f013/document.json",
+    "structureJsonPath": ".echo-pdf-workspace/documents/b1d2f6a8e9c4f013/structure.json",
+    "semanticStructureJsonPath": ".echo-pdf-workspace/documents/b1d2f6a8e9c4f013/semantic-structure.json",
+    "pagesDir": ".echo-pdf-workspace/documents/b1d2f6a8e9c4f013/pages"
+  },
+  "pageCount": 12,
+  "cacheStatus": "fresh"
+}</code></pre>
+          </div>
+        </section>
+
+        <p class="section-label">Output proof</p>
+        <section class="proof-grid">
+          <article class="panel proof-card">
+            <h2>Artifact tree a human can read fast</h2>
+            <ul class="artifact-tree">
+              <li><span>document.json</span>source path, snapshot, page count, artifact roots</li>
+              <li><span>structure.json</span>stable page index for deterministic traversal</li>
+              <li><span>semantic-structure.json</span>heading / section layer, separate from <code>pages[]</code></li>
+              <li><span>renders/0001.scale-2.png</span>page render proof, ready for visual reuse</li>
+              <li><span>ocr/0001...json</span>OCR text plus traceability back to the render artifact</li>
+            </ul>
+          </article>
+          <article class="panel">
+            <h2>Why this is useful</h2>
             <ul>
-              <li>stable page index via <code>structure.json</code></li>
-              <li>optional semantic layer via <code>semantic-structure.json</code></li>
-              <li>page JSON, render PNG, and OCR JSON artifacts under one workspace root</li>
-              <li>cache reuse keyed by source snapshot and strategy metadata</li>
+              <li>the agent gets structured files, not just prose</li>
+              <li>the human sees concrete outputs before reading deep docs</li>
+              <li>downstream local tools can reuse the same workspace instead of reparsing PDFs</li>
+              <li>cache reuse stays explicit through source snapshot and strategy metadata</li>
             </ul>
           </div>
         </section>
@@ -161,9 +196,9 @@ echo-pdf ocr ./sample.pdf --page 1 --model gpt-4.1-mini</code></pre>
           <div>
             <p class="kicker">Repository docs</p>
             <ul>
-              <li><code>docs/PRODUCT.md</code></li>
-              <li><code>docs/PACKAGING.md</code></li>
-              <li><code>docs/WORKSPACE_CONTRACT.md</code></li>
+              <li><a href="https://github.com/JFHuang746/echo-pdf/blob/master/docs/PRODUCT.md">docs/PRODUCT.md</a></li>
+              <li><a href="https://github.com/JFHuang746/echo-pdf/blob/master/docs/PACKAGING.md">docs/PACKAGING.md</a></li>
+              <li><a href="https://github.com/JFHuang746/echo-pdf/blob/master/docs/WORKSPACE_CONTRACT.md">docs/WORKSPACE_CONTRACT.md</a></li>
             </ul>
           </div>
         </div>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,32 @@
+# echo-pdf docs
+
+Site: https://pdf.echofile.ai/
+Product: local-first PDF context engine for AI agents
+Boundary: docs-only site; not a hosted PDF processing service
+
+Primary surfaces:
+- npm package: @echofiles/echo-pdf
+- local CLI: echo-pdf
+- local workspace artifacts: .echo-pdf-workspace/
+
+Core local primitives:
+- get_document
+- get_document_structure
+- get_semantic_document_structure
+- get_page_content
+- get_page_render
+- get_page_ocr
+
+Key docs:
+- Overview: https://pdf.echofile.ai/
+- API: https://pdf.echofile.ai/api/index.html
+- CLI: https://pdf.echofile.ai/cli/index.html
+- Page index: https://pdf.echofile.ai/concepts/page-index.html
+- Semantic structure: https://pdf.echofile.ai/concepts/semantic-structure.html
+- Workspace artifacts: https://pdf.echofile.ai/concepts/workspace-artifacts.html
+- Integrations: https://pdf.echofile.ai/integrations/index.html
+
+Non-goals:
+- hosted SaaS
+- MCP as primary entrypoint
+- domain-specific extraction logic

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://pdf.echofile.ai/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://pdf.echofile.ai/</loc>
+  </url>
+  <url>
+    <loc>https://pdf.echofile.ai/api/index.html</loc>
+  </url>
+  <url>
+    <loc>https://pdf.echofile.ai/cli/index.html</loc>
+  </url>
+  <url>
+    <loc>https://pdf.echofile.ai/concepts/page-index.html</loc>
+  </url>
+  <url>
+    <loc>https://pdf.echofile.ai/concepts/semantic-structure.html</loc>
+  </url>
+  <url>
+    <loc>https://pdf.echofile.ai/concepts/workspace-artifacts.html</loc>
+  </url>
+  <url>
+    <loc>https://pdf.echofile.ai/integrations/index.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- improve the published docs site for both agents and humans without changing the product/runtime surface
- add real machine-consumable discovery files: `llms.txt`, `robots.txt`, and `sitemap.xml`
- strengthen the homepage with an explicit agent-first happy path, a copyable structured output example, and a proof-oriented artifact tree
- add social preview metadata and make footer repo-doc references clickable
- switch the published static asset directory to `site/` so the docs site, not the old console asset bundle, is what gets served

## Touched Runtime Boundary
- no product runtime changes
- no API changes
- no CLI contract changes
- no runtime refactor
- docs/site surfaces and static publishing content only

## Updated Docs/Site Surfaces
- `site/index.html`
- `site/assets/styles.css`
- `site/llms.txt`
- `site/robots.txt`
- `site/sitemap.xml`
- `wrangler.toml` (`[assets].directory` now points at `./site`)

## Local Checks Run
- local static-server check with `python3 -m http.server 4173 --directory site`
- `curl http://127.0.0.1:4173/llms.txt`
- `curl http://127.0.0.1:4173/robots.txt`
- `curl http://127.0.0.1:4173/sitemap.xml`
- `curl http://127.0.0.1:4173/` and grep checks for:
  - social preview metadata
  - homepage proof/example blocks
  - clickable footer repo-doc links
- internal relative-link sanity check across all HTML files under `site/`
- wording sanity check to confirm the site remains local-first / docs-only and does not imply hosted SaaS or MCP-as-primary

## Intentionally Not Covered
- no product implementation cleanup outside the docs site
- no hosted demo / SaaS / playground work
- no share image asset in this PR
- browser-based visual QA was attempted, but local browser tooling was unreliable in this environment; the final verification here is curl/static sanity rather than screenshot-based approval

Closes #59
