### PR TITLE
cleanup(cli): remove legacy command aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,21 +63,10 @@ echo-pdf render ./sample.pdf --page 1
 echo-pdf ocr ./sample.pdf --page 1 --model gpt-4.1-mini
 ```
 
-源码 checkout 的本地开发路径：
-
-```bash
-npm install
-npm run document:dev -- document ./fixtures/smoke.pdf
-npm run document:dev -- structure ./fixtures/smoke.pdf
-npm run document:dev -- semantic ./fixtures/smoke.pdf
-npm run document:dev -- page ./fixtures/smoke.pdf --page 1
-```
-
 说明：
 
 - 发布包 / 已构建 checkout：`echo-pdf document ...` 继续走 `dist/`
-- 源码 checkout 且还没 build：使用 `npm run document:dev -- ...`
-- `document:dev` 只用于本地开发；它会显式优先加载 `src/local/index.ts`，即使仓库里仍然存在旧 `dist/`
+- 仓库内部如需 source-checkout CLI 调试，走 `docs/DEVELOPMENT.md` 中记录的开发路径；它不属于公开 CLI 命令面
 - 发布包和正常 `echo-pdf document ...` 仍然只走 `dist/`
 
 默认会在当前目录写入可检查的 workspace：
@@ -322,10 +311,10 @@ echo-pdf config set --key service.maxPagesPerRequest --value 20
 - `render <file.pdf> --page <N>` -> `get_page_render`
 - `ocr <file.pdf> --page <N>` -> `get_page_ocr`
 
-兼容边界：
+CLI 边界：
 
-- 旧的 `document get|index|structure|semantic|page|render|ocr ...` 仍作为兼容别名保留
-- README 和 `--help` 现在优先展示这六个主命令，而不是旧的子命令树
+- 对外支持的本地 document 命令面只有这六个顶层 primitives
+- 旧的 `document get|index|structure|semantic|page|render|ocr ...` 兼容别名已移除
 
 建立本地索引并输出 metadata：
 

--- a/bin/echo-pdf.js
+++ b/bin/echo-pdf.js
@@ -334,8 +334,8 @@ const loadLocalDocumentApi = async () => {
       return import(LOCAL_DOCUMENT_SOURCE_ENTRY.href)
     }
     throw new Error(
-      "Source-checkout document dev mode requires Bun and src/local/index.ts. " +
-      "Use `npm run document:dev -- <command> ...` from a source checkout."
+      "Internal source-checkout CLI dev mode requires Bun and src/local/index.ts. " +
+      "Use `npm run cli:dev -- <primitive> ...` only from a source checkout."
     )
   }
   try {
@@ -344,8 +344,8 @@ const loadLocalDocumentApi = async () => {
     const code = error && typeof error === "object" ? error.code : ""
     if (code === "ERR_MODULE_NOT_FOUND") {
       throw new Error(
-        "Local document commands require built artifacts in a source checkout. " +
-        "Run `npm run build` first, use `npm run document:dev -- <command> ...` in a source checkout, or install the published package."
+        "Local primitive commands require built artifacts in a source checkout. " +
+        "Run `npm run build` first, use the internal `npm run cli:dev -- <primitive> ...` path in this repo, or install the published package."
       )
     }
     throw error
@@ -353,21 +353,37 @@ const loadLocalDocumentApi = async () => {
 }
 
 const LOCAL_PRIMITIVE_COMMANDS = ["document", "structure", "semantic", "page", "render", "ocr"]
-const LEGACY_DOCUMENT_SUBCOMMANDS = ["index", "get", "structure", "semantic", "page", "render", "ocr"]
+const REMOVED_DOCUMENT_ALIAS_TO_PRIMITIVE = {
+  index: "document",
+  get: "document",
+  structure: "structure",
+  semantic: "semantic",
+  page: "page",
+  render: "render",
+  ocr: "ocr",
+}
 
-const isLegacyDocumentSubcommand = (value) => typeof value === "string" && LEGACY_DOCUMENT_SUBCOMMANDS.includes(value)
+const isRemovedDocumentAlias = (value) =>
+  typeof value === "string" && Object.hasOwn(REMOVED_DOCUMENT_ALIAS_TO_PRIMITIVE, value)
+
+const removedDocumentAliasMessage = (alias) => {
+  const primitive = REMOVED_DOCUMENT_ALIAS_TO_PRIMITIVE[alias]
+  return `Legacy \`document ${alias}\` was removed. Use \`echo-pdf ${primitive} <file.pdf>\` instead.`
+}
 
 const readDocumentPrimitiveArgs = (command, subcommand, rest) => {
-  if (command === "document" && isLegacyDocumentSubcommand(subcommand)) {
-    const primitive = subcommand === "index" || subcommand === "get" ? "document" : subcommand
+  if (command === "document") {
+    if (isRemovedDocumentAlias(subcommand) && typeof rest[0] === "string" && !rest[0].startsWith("--")) {
+      throw new Error(removedDocumentAliasMessage(subcommand))
+    }
     return {
-      primitive,
-      pdfPath: rest[0],
+      primitive: "document",
+      pdfPath: subcommand,
     }
   }
   return {
     primitive: command,
-    pdfPath: command === "document" ? subcommand : rest[0],
+    pdfPath: rest[0],
   }
 }
 
@@ -443,14 +459,14 @@ const runLocalPrimitiveCommand = async (command, subcommand, rest, flags) => {
 
 const usage = () => {
   process.stdout.write(`echo-pdf CLI\n\n`)
-  process.stdout.write(`Commands:\n`)
+  process.stdout.write(`Primary local primitive commands:\n`)
   process.stdout.write(`  document <file.pdf> [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  structure <file.pdf> [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  semantic <file.pdf> [--provider alias] [--model model] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  page <file.pdf> --page <N> [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  render <file.pdf> --page <N> [--scale N] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  ocr <file.pdf> --page <N> [--scale N] [--provider alias] [--model model] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
-  process.stdout.write(`\nCompatibility / existing service commands:\n`)
+  process.stdout.write(`\nAdditional commands:\n`)
   process.stdout.write(`  init [--service-url URL]\n`)
   process.stdout.write(`  dev [--port 8788] [--host 127.0.0.1]\n`)
   process.stdout.write(`  provider set --provider <${PROVIDER_SET_NAMES.join("|")}> --api-key <KEY> [--profile name]\n`)
@@ -463,12 +479,6 @@ const usage = () => {
   process.stdout.write(`  model list [--profile name]\n`)
   process.stdout.write(`  tools\n`)
   process.stdout.write(`  call --tool <name> --args '<json>' [--provider alias] [--model model] [--profile name] [--auto-upload]\n`)
-  process.stdout.write(`  document get <file.pdf> [--workspace DIR] [--force-refresh]\n`)
-  process.stdout.write(`  document structure <file.pdf> [--workspace DIR] [--force-refresh]\n`)
-  process.stdout.write(`  document semantic <file.pdf> [--provider alias] [--model model] [--workspace DIR] [--force-refresh]\n`)
-  process.stdout.write(`  document page <file.pdf> --page <N> [--workspace DIR] [--force-refresh]\n`)
-  process.stdout.write(`  document render <file.pdf> --page <N> [--scale N] [--workspace DIR] [--force-refresh]\n`)
-  process.stdout.write(`  document ocr <file.pdf> --page <N> [--scale N] [--provider alias] [--model model] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  file upload <local.pdf>\n`)
   process.stdout.write(`  file get --file-id <id> --out <path>\n`)
   process.stdout.write(`  mcp initialize\n`)
@@ -719,7 +729,7 @@ const main = async () => {
     return
   }
 
-  if (LOCAL_PRIMITIVE_COMMANDS.includes(command) || (command === "document" && isLegacyDocumentSubcommand(subcommand))) {
+  if (LOCAL_PRIMITIVE_COMMANDS.includes(command)) {
     await runLocalPrimitiveCommand(command, subcommand, rest, flags)
     return
   }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -60,6 +60,8 @@ Rules:
 - Prefer explicit local workflows over hosted assumptions.
 - Local artifacts should be inspectable and reusable.
 - Repeated local runs should reuse prior artifacts/workspace when reasonable.
+- Repo-internal source-checkout CLI debugging can use `npm run cli:dev -- <primitive> ...`.
+- `cli:dev` is an internal development helper only, not part of the public CLI/documentation surface.
 - Eval operations for issue `#42` live under `eval/` and `docs/EVAL_*.md`.
 
 ## Pull Request Expectations

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check:runtime": "bash ./scripts/check-runtime.sh",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "document:dev": "ECHO_PDF_SOURCE_DEV=1 bun ./bin/echo-pdf.js",
+    "cli:dev": "ECHO_PDF_SOURCE_DEV=1 bun ./bin/echo-pdf.js",
     "eval": "node ./eval/run-local.mjs",
     "eval:smoke": "node ./eval/run-local.mjs --suite smoke",
     "eval:core": "node ./eval/run-local.mjs --suite core",

--- a/site/cli/index.html
+++ b/site/cli/index.html
@@ -23,7 +23,7 @@
           <span class="eyebrow">CLI</span>
           <h1>One command surface, same six primitives.</h1>
           <p class="lead">
-            The local CLI is aligned to the same six primitives as the package API. Use top-level commands for the mainline workflow; legacy aliases may remain for compatibility.
+            The local CLI is aligned to the same six primitives as the package API. Use the top-level primitive commands directly.
           </p>
         </section>
 
@@ -39,12 +39,12 @@ echo-pdf ocr ./sample.pdf --page 1 --model gpt-4.1-mini</code></pre>
 
         <section class="two-col" style="margin-top:28px;">
           <article class="panel">
-            <h2>Source checkout workflow</h2>
-            <pre><code>npm install
-npm run document:dev -- document ./fixtures/smoke.pdf
-npm run document:dev -- structure ./fixtures/smoke.pdf
-npm run document:dev -- semantic ./fixtures/smoke.pdf
-npm run document:dev -- page ./fixtures/smoke.pdf --page 1</code></pre>
+            <h2>Supported boundary</h2>
+            <ul>
+              <li>the public local CLI surface is the same six top-level primitives shown above</li>
+              <li>legacy <code>document ...</code> alias trees are not part of the supported docs path</li>
+              <li>workspace-writing local runs stay the mainline workflow</li>
+            </ul>
           </article>
           <article class="panel">
             <h2>What stays out of the way</h2>

--- a/tests/integration/local-document-cli.integration.test.ts
+++ b/tests/integration/local-document-cli.integration.test.ts
@@ -31,8 +31,21 @@ const runCli = async (repoDir: string, args: string[]): Promise<{ stdout: string
   return { stdout, stderr }
 }
 
-const runSourceCheckoutDocumentDev = async (repoDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> => {
-  const { stdout, stderr } = await execFileAsync("npm", ["run", "document:dev", "--", ...args], {
+const runCliFailure = async (repoDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> => {
+  try {
+    await runCli(repoDir, args)
+  } catch (error) {
+    const failure = error as { stdout?: string; stderr?: string }
+    return {
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? "",
+    }
+  }
+  throw new Error(`Expected CLI failure for args: ${args.join(" ")}`)
+}
+
+const runSourceCheckoutCliDev = async (repoDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> => {
+  const { stdout, stderr } = await execFileAsync("npm", ["run", "cli:dev", "--", ...args], {
     cwd: repoDir,
     env: process.env,
   })
@@ -118,23 +131,29 @@ describe("local document CLI", () => {
     expect(stored.documentId).toBe(doc.documentId)
   })
 
-  itWithNode20("keeps legacy document subcommands as compatibility aliases", async () => {
-    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-legacy-"))
+  itWithNode20("prints help around the six top-level primitives only", async () => {
+    const { stdout } = await runCli(rootDir, ["--help"])
 
-    const { stdout: docRaw } = await runCli(rootDir, ["document", "get", fixturePdf, "--workspace", workspaceDir])
-    const { stdout: structureRaw } = await runCli(rootDir, ["document", "structure", fixturePdf, "--workspace", workspaceDir])
-    const { stdout: semanticRaw } = await runCli(rootDir, ["document", "semantic", fixturePdf, "--workspace", workspaceDir])
-    const { stdout: pageRaw } = await runCli(rootDir, ["document", "page", fixturePdf, "--page", "1", "--workspace", workspaceDir])
-    const { stdout: renderRaw } = await runCli(rootDir, ["document", "render", fixturePdf, "--page", "1", "--workspace", workspaceDir])
-
-    expect(JSON.parse(docRaw).documentId).toBeTruthy()
-    expect(JSON.parse(structureRaw).root.type).toBe("document")
-    expect(JSON.parse(semanticRaw).root.type).toBe("document")
-    expect(JSON.parse(pageRaw).pageNumber).toBe(1)
-    expect(JSON.parse(renderRaw).mimeType).toBe("image/png")
+    expect(stdout).toContain("Primary local primitive commands:")
+    expect(stdout).toContain("  document <file.pdf>")
+    expect(stdout).toContain("  structure <file.pdf>")
+    expect(stdout).toContain("  semantic <file.pdf>")
+    expect(stdout).toContain("  page <file.pdf> --page <N>")
+    expect(stdout).toContain("  render <file.pdf> --page <N> [--scale N]")
+    expect(stdout).toContain("  ocr <file.pdf> --page <N> [--scale N]")
+    expect(stdout).not.toContain("document get <file.pdf>")
+    expect(stdout).not.toContain("document structure <file.pdf>")
+    expect(stdout).not.toContain("document semantic <file.pdf>")
   })
 
-  itWithNode20AndBun("supports a source-checkout document workflow even when dist artifacts exist", async () => {
+  itWithNode20("rejects removed legacy document aliases with migration guidance", async () => {
+    const { stderr } = await runCliFailure(rootDir, ["document", "get", fixturePdf])
+
+    expect(stderr).toContain("Legacy `document get` was removed.")
+    expect(stderr).toContain("Use `echo-pdf document <file.pdf>` instead.")
+  })
+
+  itWithNode20AndBun("supports the internal source-checkout cli:dev workflow even when dist artifacts exist", async () => {
     const checkoutDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-source-"))
     await cp(path.join(rootDir, "bin"), path.join(checkoutDir, "bin"), { recursive: true })
     await cp(path.join(rootDir, "dist"), path.join(checkoutDir, "dist"), { recursive: true })
@@ -144,11 +163,11 @@ describe("local document CLI", () => {
     await symlink(path.join(rootDir, "node_modules"), path.join(checkoutDir, "node_modules"), "dir")
     await writeFile(
       path.join(checkoutDir, "dist", "local", "index.js"),
-      'throw new Error("dist local entry should not load in document:dev");\n',
+      'throw new Error("dist local entry should not load in cli:dev");\n',
       "utf-8"
     )
 
-    const { stdout } = await runSourceCheckoutDocumentDev(checkoutDir, ["document", fixturePdf, "--workspace", checkoutDir])
+    const { stdout } = await runSourceCheckoutCliDev(checkoutDir, ["document", fixturePdf, "--workspace", checkoutDir])
     const doc = JSON.parse(stdout.replace(/^>.*\n/gm, "").trim()) as {
       pageCount: number
       cacheStatus: "fresh" | "reused"


### PR DESCRIPTION
## Summary
- remove the deprecated `document get|index|structure|semantic|page|render|ocr` compatibility aliases so the public local CLI only exposes the six supported top-level primitives: `document`, `structure`, `semantic`, `page`, `render`, and `ocr`
- keep the source-checkout helper but rename `document:dev` to internal-only `cli:dev`, and move its boundary into development docs rather than public README/help/docs-site guidance
- update `--help`, `README`, docs-site CLI copy, and CLI integration tests so the supported user-facing command surface is the slimmer primitive-only interface

## Compatibility Surface
- Deleted compatibility entries: `document get`, `document index`, `document structure`, `document semantic`, `document page`, `document render`, `document ocr`
- Kept compatibility paths: none in the public local document command tree
- Retained internal helper: `npm run cli:dev -- <primitive> ...`
- Why retained: source-checkout CLI debugging still benefits from a path that explicitly prefers `src/local/index.ts` over stale `dist/`, but that path is now documented as repo-internal only and not part of the product CLI boundary

## User-visible CLI Boundary
- Public local CLI guidance now points only to the six top-level primitives
- Legacy `document ...` alias usage now fails with migration guidance to the canonical top-level command
- `document:dev` no longer exists as a public-facing script name; the remaining helper is internal and documented only in `docs/DEVELOPMENT.md`

## Runtime Boundary
- Node CLI only

## Validation
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npx vitest run tests/integration/local-document-cli.integration.test.ts`

## Intentionally Not Changed
- package `exports`
- semantic / OCR / render / workspace artifact behavior
- MCP / Worker / SaaS surfaces
- new CLI commands

Made with [Cursor](https://cursor.com)