### PR TITLE
chore(ci): tighten npm publish and add pages deploy

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,27 +9,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          cache: npm
           registry-url: "https://registry.npmjs.org"
-      - run: npm ci
-      - run: npm run typecheck
-      - run: npm test
-      - name: Verify npm auth token
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "${NODE_AUTH_TOKEN}" ]; then
-            echo "NPM_TOKEN secret is empty or unavailable"
-            exit 1
-          fi
-          npm whoami
+
       - name: Check if version already exists
         id: pkg
         run: |
@@ -43,7 +38,36 @@ jobs:
           else
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
-      - run: npm publish --access public
+
+      - name: Install dependencies
+        if: steps.pkg.outputs.should_publish == 'true'
+        run: npm ci
+
+      - name: Runtime check
+        if: steps.pkg.outputs.should_publish == 'true'
+        run: npm run check:runtime
+
+      - name: Typecheck
+        if: steps.pkg.outputs.should_publish == 'true'
+        run: npm run typecheck
+
+      - name: Test
+        if: steps.pkg.outputs.should_publish == 'true'
+        run: npm test
+
+      - name: Verify npm auth token
         if: steps.pkg.outputs.should_publish == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "NPM_TOKEN secret is empty or unavailable"
+            exit 1
+          fi
+          npm whoami
+
+      - name: Publish package
+        if: steps.pkg.outputs.should_publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/pages-site.yml
+++ b/.github/workflows/pages-site.yml
@@ -1,0 +1,40 @@
+name: Deploy Docs Site
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages-site.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-site-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate Cloudflare secrets
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          test -n "$CF_API_TOKEN" || (echo "Missing secret: CLOUDFLARE_API_TOKEN" && exit 1)
+          test -n "$CF_ACCOUNT_ID" || (echo "Missing secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
+
+      - name: Deploy static docs to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy site --project-name=echo-pdf-docs


### PR DESCRIPTION
This PR only updates GitHub Actions workflow behavior.

Changes:
- check npm version existence before installing/testing/publishing
- add concurrency to npm publish
- add Cloudflare Pages docs-site deploy workflow for `site/` changes

Non-goals:
- no product code changes
- no CLI or package surface changes