### PR TITLE
#70 feat(local): emit LaTeX-first table and formula artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `echo-pdf` is a local-first, vision-language-first PDF context engine for AI agents.
 
-It turns a local PDF into reusable CLI outputs, Node/Bun library primitives, and inspectable workspace artifacts for page rendering, page understanding, semantic structure, and downstream local reuse.
+It turns a local PDF into reusable CLI outputs, Node/Bun library primitives, and inspectable workspace artifacts for page rendering, page understanding, semantic structure, LaTeX-first tables, LaTeX-first formulas, and downstream local reuse.
 
 ## What It Is
 
@@ -91,6 +91,10 @@ By default, `echo-pdf` writes reusable artifacts into a local workspace:
     renders/
       0001.scale-2.json
       0001.scale-2.png
+    tables/
+      0006.scale-2.provider-openai.model-gpt-4_1-mini.prompt-<hash>.json
+    formulas/
+      0004.scale-2.provider-openai.model-gpt-4_1-mini.prompt-<hash>.json
 ```
 
 These artifacts are meant to be inspected, cached, and reused by downstream local tools.
@@ -105,6 +109,8 @@ import {
   get_semantic_document_structure,
   get_page_content,
   get_page_render,
+  get_page_tables_latex,
+  get_page_formulas_latex,
 } from "@echofiles/echo-pdf/local"
 
 const document = await get_document({ pdfPath: "./sample.pdf" })
@@ -112,6 +118,8 @@ const structure = await get_document_structure({ pdfPath: "./sample.pdf" })
 const semantic = await get_semantic_document_structure({ pdfPath: "./sample.pdf" })
 const page1 = await get_page_content({ pdfPath: "./sample.pdf", pageNumber: 1 })
 const render1 = await get_page_render({ pdfPath: "./sample.pdf", pageNumber: 1, scale: 2 })
+const tables = await get_page_tables_latex({ pdfPath: "./paper.pdf", pageNumber: 6, provider: "openai", model: "gpt-4.1-mini" })
+const formulas = await get_page_formulas_latex({ pdfPath: "./paper.pdf", pageNumber: 4, provider: "openai", model: "gpt-4.1-mini" })
 ```
 
 Notes:
@@ -119,6 +127,8 @@ Notes:
 - `get_document_structure()` returns the stable page index: `document -> pages[]`
 - `get_semantic_document_structure()` returns a separate semantic structure layer; it does not replace `pages[]`
 - `get_page_render()` materializes a reusable PNG plus render metadata and is the mainline visual input path
+- `get_page_tables_latex()` materializes page-level LaTeX tabular artifacts with page/render traceability
+- `get_page_formulas_latex()` materializes page-level LaTeX math artifacts with page/render traceability
 
 Migration note:
 

--- a/docs/WORKSPACE_CONTRACT.md
+++ b/docs/WORKSPACE_CONTRACT.md
@@ -4,7 +4,7 @@ This document defines the local workspace artifact contract for `echo-pdf`.
 
 It is the contract downstream local apps and operators may rely on when they read `.echo-pdf-workspace/` directly.
 
-The mainline artifact story in the current phase is document metadata, page artifacts, render artifacts, and semantic structure.
+The mainline artifact story in the current phase is document metadata, page artifacts, render artifacts, semantic structure, and LaTeX-first structured technical artifacts.
 
 ## Scope
 
@@ -45,6 +45,12 @@ Callers may override the root with `workspaceDir` or `--workspace`.
         0001.scale-2.json
         0001.scale-2.png
         ...
+      tables/
+        0006.scale-2.provider-openai.model-gpt-4_1-mini.prompt-<hash>.json
+        ...
+      formulas/
+        0004.scale-2.provider-openai.model-gpt-4_1-mini.prompt-<hash>.json
+        ...
 ```
 
 Layout rules:
@@ -52,6 +58,8 @@ Layout rules:
 - `document.json`, `structure.json`, and `pages/*.json` are the required baseline artifacts after document indexing.
 - `semantic-structure.json` is materialized only after semantic extraction runs.
 - `renders/*` artifacts are materialized only after page rendering runs.
+- `tables/*` artifacts are materialized only after page-level table extraction runs.
+- `formulas/*` artifacts are materialized only after page-level formula extraction runs.
 
 Migration-only note:
 
@@ -214,6 +222,68 @@ Downstream use:
 - visual page inspection
 - VL input reuse without rerendering the same page
 - optional OCR fallback/image reuse when that path is explicitly invoked
+
+### `tables/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`
+
+Optional page-level structured table artifact.
+
+Required JSON fields:
+
+- `documentId`
+- `pageNumber`
+- `renderScale`
+- `sourceSizeBytes`
+- `sourceMtimeMs`
+- `provider`
+- `model`
+- `prompt`
+- `imagePath`
+- `pageArtifactPath`
+- `renderArtifactPath`
+- `artifactPath`
+- `generatedAt`
+- `tables`
+
+Each `tables[]` item must expose:
+
+- `id`
+- `latexTabular`
+
+Optional item fields:
+
+- `caption`
+- `evidenceText`
+
+### `formulas/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`
+
+Optional page-level structured formula artifact.
+
+Required JSON fields:
+
+- `documentId`
+- `pageNumber`
+- `renderScale`
+- `sourceSizeBytes`
+- `sourceMtimeMs`
+- `provider`
+- `model`
+- `prompt`
+- `imagePath`
+- `pageArtifactPath`
+- `renderArtifactPath`
+- `artifactPath`
+- `generatedAt`
+- `formulas`
+
+Each `formulas[]` item must expose:
+
+- `id`
+- `latexMath`
+
+Optional item fields:
+
+- `label`
+- `evidenceText`
 
 ## Cache Semantics
 

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -20,6 +20,8 @@ export interface LocalDocumentArtifactPaths {
   readonly semanticStructureJsonPath: string
   readonly pagesDir: string
   readonly rendersDir: string
+  readonly tablesDir: string
+  readonly formulasDir: string
 }
 
 interface InternalDocumentArtifactPaths extends LocalDocumentArtifactPaths {
@@ -108,6 +110,56 @@ export interface LocalPageRenderArtifact {
   readonly cacheStatus: "fresh" | "reused"
 }
 
+export interface LocalTableArtifactItem {
+  readonly id: string
+  readonly latexTabular: string
+  readonly caption?: string
+  readonly evidenceText?: string
+}
+
+export interface LocalFormulaArtifactItem {
+  readonly id: string
+  readonly latexMath: string
+  readonly label?: string
+  readonly evidenceText?: string
+}
+
+export interface LocalPageTablesArtifact {
+  readonly documentId: string
+  readonly pageNumber: number
+  readonly renderScale: number
+  readonly sourceSizeBytes: number
+  readonly sourceMtimeMs: number
+  readonly provider: string
+  readonly model: string
+  readonly prompt: string
+  readonly imagePath: string
+  readonly pageArtifactPath: string
+  readonly renderArtifactPath: string
+  readonly artifactPath: string
+  readonly generatedAt: string
+  readonly tables: ReadonlyArray<LocalTableArtifactItem>
+  readonly cacheStatus: "fresh" | "reused"
+}
+
+export interface LocalPageFormulasArtifact {
+  readonly documentId: string
+  readonly pageNumber: number
+  readonly renderScale: number
+  readonly sourceSizeBytes: number
+  readonly sourceMtimeMs: number
+  readonly provider: string
+  readonly model: string
+  readonly prompt: string
+  readonly imagePath: string
+  readonly pageArtifactPath: string
+  readonly renderArtifactPath: string
+  readonly artifactPath: string
+  readonly generatedAt: string
+  readonly formulas: ReadonlyArray<LocalFormulaArtifactItem>
+  readonly cacheStatus: "fresh" | "reused"
+}
+
 interface LocalPageOcrArtifact {
   readonly documentId: string
   readonly pageNumber: number
@@ -151,6 +203,22 @@ export interface LocalSemanticDocumentRequest extends LocalDocumentRequest {
 
 export interface LocalPageRenderRequest extends LocalPageContentRequest {
   readonly renderScale?: number
+}
+
+export interface LocalPageTablesRequest extends LocalPageRenderRequest {
+  readonly provider?: string
+  readonly model?: string
+  readonly prompt?: string
+  readonly env?: Env
+  readonly providerApiKeys?: Record<string, string>
+}
+
+export interface LocalPageFormulasRequest extends LocalPageRenderRequest {
+  readonly provider?: string
+  readonly model?: string
+  readonly prompt?: string
+  readonly env?: Env
+  readonly providerApiKeys?: Record<string, string>
 }
 
 interface LocalPageOcrRequest extends LocalPageRenderRequest {
@@ -199,6 +267,8 @@ const buildArtifactPaths = (workspaceDir: string, documentId: string): InternalD
     semanticStructureJsonPath: path.join(documentDir, "semantic-structure.json"),
     pagesDir: path.join(documentDir, "pages"),
     rendersDir: path.join(documentDir, "renders"),
+    tablesDir: path.join(documentDir, "tables"),
+    formulasDir: path.join(documentDir, "formulas"),
     ocrDir: path.join(documentDir, "ocr"),
   }
 }
@@ -211,6 +281,8 @@ const toPublicArtifactPaths = (paths: InternalDocumentArtifactPaths): LocalDocum
   semanticStructureJsonPath: paths.semanticStructureJsonPath,
   pagesDir: paths.pagesDir,
   rendersDir: paths.rendersDir,
+  tablesDir: paths.tablesDir,
+  formulasDir: paths.formulasDir,
 })
 
 const buildRenderArtifactPaths = (
@@ -243,6 +315,24 @@ const buildOcrArtifactPath = (
   return path.join(paths.ocrDir, `${key}.json`)
 }
 
+const buildStructuredArtifactPath = (
+  baseDir: string,
+  pageNumber: number,
+  renderScale: number,
+  provider: string,
+  model: string,
+  prompt: string
+): string => {
+  const key = [
+    pageLabel(pageNumber),
+    `scale-${scaleLabel(renderScale)}`,
+    `provider-${sanitizeSegment(provider)}`,
+    `model-${sanitizeSegment(model)}`,
+    `prompt-${hashFragment(prompt, 10)}`,
+  ].join(".")
+  return path.join(baseDir, `${key}.json`)
+}
+
 const createPreview = (text: string): string => text.replace(/\s+/g, " ").trim().slice(0, 160)
 
 const createPageTitle = (pageNumber: number, text: string): string => {
@@ -272,6 +362,44 @@ const parseJsonObject = (value: string): unknown => {
     }
     throw new Error("semantic structure model output was not valid JSON")
   }
+}
+
+const normalizeTableItems = (value: unknown): LocalTableArtifactItem[] => {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item, index) => {
+    const table = item as {
+      latexTabular?: unknown
+      caption?: unknown
+      evidenceText?: unknown
+    }
+    const latexTabular = typeof table.latexTabular === "string" ? stripCodeFences(table.latexTabular).trim() : ""
+    if (!latexTabular.includes("\\begin{tabular}") || !latexTabular.includes("\\end{tabular}")) return []
+    return [{
+      id: `table-${index + 1}`,
+      latexTabular,
+      caption: typeof table.caption === "string" ? table.caption.trim() : undefined,
+      evidenceText: typeof table.evidenceText === "string" ? table.evidenceText.trim() : undefined,
+    }]
+  })
+}
+
+const normalizeFormulaItems = (value: unknown): LocalFormulaArtifactItem[] => {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item, index) => {
+    const formula = item as {
+      latexMath?: unknown
+      label?: unknown
+      evidenceText?: unknown
+    }
+    const latexMath = typeof formula.latexMath === "string" ? stripCodeFences(formula.latexMath).trim() : ""
+    if (!latexMath) return []
+    return [{
+      id: `formula-${index + 1}`,
+      latexMath,
+      label: typeof formula.label === "string" ? formula.label.trim() : undefined,
+      evidenceText: typeof formula.evidenceText === "string" ? formula.evidenceText.trim() : undefined,
+    }]
+  })
 }
 
 const resolveEnv = (env?: Env): Env => env ?? (process.env as unknown as Env)
@@ -487,6 +615,65 @@ const buildSemanticAggregationPrompt = (
   ].join("\n")
 }
 
+const buildTableExtractionPrompt = (
+  page: LocalPageContent,
+  renderScale: number
+): string => [
+  "You extract structured table artifacts from one rendered PDF page.",
+  "Primary evidence is the page image layout. Use the extracted page text only as supporting context.",
+  "Return JSON only.",
+  "Schema:",
+  "{",
+  '  "tables": [',
+  "    {",
+  '      "latexTabular": "\\\\begin{tabular}...\\\\end{tabular}",',
+  '      "caption": "string",',
+  '      "evidenceText": "short evidence string"',
+  "    }",
+  "  ]",
+  "}",
+  "Rules:",
+  "- Only emit actual tables visible on the page.",
+  "- latexTabular must contain valid LaTeX tabular markup.",
+  "- Do not emit prose paragraphs, equations, figure labels, or narrative lists as tables.",
+  "- Preserve the visible row/column structure.",
+  "- If no table is present, return {\"tables\":[]}.",
+  `Page number: ${page.pageNumber}`,
+  `Render scale: ${renderScale}`,
+  "",
+  "Extracted page text:",
+  page.text,
+].join("\n")
+
+const buildFormulaExtractionPrompt = (
+  page: LocalPageContent,
+  renderScale: number
+): string => [
+  "You extract structured formula artifacts from one rendered PDF page.",
+  "Primary evidence is the page image layout. Use the extracted page text only as supporting context.",
+  "Return JSON only.",
+  "Schema:",
+  "{",
+  '  "formulas": [',
+  "    {",
+  '      "latexMath": "latex math string",',
+  '      "label": "optional equation label",',
+  '      "evidenceText": "short evidence string"',
+  "    }",
+  "  ]",
+  "}",
+  "Rules:",
+  "- Only emit displayed formulas or clearly isolated mathematical expressions.",
+  "- latexMath must be valid LaTeX math content.",
+  "- Do not emit prose, captions, table cells, or units-only fragments as formulas.",
+  "- If no formula is present, return {\"formulas\":[]}.",
+  `Page number: ${page.pageNumber}`,
+  `Render scale: ${renderScale}`,
+  "",
+  "Extracted page text:",
+  page.text,
+].join("\n")
+
 const buildHeuristicSemanticArtifact = (
   record: StoredDocumentRecord,
   artifactPath: string,
@@ -547,6 +734,18 @@ const extractSemanticCandidatesFromRenderedPage = async (input: {
 const summarizeSemanticAgentFailure = (error: unknown): string => {
   const message = error instanceof Error ? error.message : String(error)
   return message.replace(/\s+/g, " ").trim().slice(0, 240) || "unknown agent semantic failure"
+}
+
+const resolveAgentSelection = (
+  config: EchoPdfConfig,
+  input: { provider?: string; model?: string }
+): { provider: string; model: string } => {
+  const provider = resolveProviderAlias(config, input.provider)
+  const model = resolveModelForProvider(config, provider, input.model)
+  if (!model) {
+    throw new Error(`model is required for VL-first structured artifacts; pass \`model\` or set agent.defaultModel for provider "${provider}"`)
+  }
+  return { provider, model }
 }
 
 const ensureSemanticStructureArtifact = async (
@@ -825,6 +1024,140 @@ export const get_page_content = async (request: LocalPageContentRequest): Promis
 
 export const get_page_render = async (request: LocalPageRenderRequest): Promise<LocalPageRenderArtifact> =>
   ensureRenderArtifact(request)
+
+export const get_page_tables_latex = async (
+  request: LocalPageTablesRequest
+): Promise<LocalPageTablesArtifact> => {
+  const env = resolveEnv(request.env)
+  const config = resolveConfig(request.config, env)
+  const { provider, model } = resolveAgentSelection(config, request)
+  const { record } = await indexDocumentInternal(request)
+  ensurePageNumber(record.pageCount, request.pageNumber)
+
+  const page = await get_page_content(request)
+  const renderArtifact = await ensureRenderArtifact(request)
+  const prompt = request.prompt?.trim() || "Extract all actual tables from this PDF page as LaTeX tabular."
+  const artifactPath = buildStructuredArtifactPath(
+    record.artifactPaths.tablesDir,
+    request.pageNumber,
+    renderArtifact.renderScale,
+    provider,
+    model,
+    prompt
+  )
+
+  if (!request.forceRefresh && await fileExists(artifactPath)) {
+    const cached = await readJson<Omit<LocalPageTablesArtifact, "cacheStatus"> & { cacheStatus?: unknown }>(artifactPath)
+    if (matchesSourceSnapshot(cached, record)) {
+      return {
+        ...cached,
+        cacheStatus: "reused",
+      }
+    }
+  }
+
+  const imageBytes = new Uint8Array(await readFile(renderArtifact.imagePath))
+  const imageDataUrl = toDataUrl(imageBytes, renderArtifact.mimeType)
+  const raw = await visionRecognize({
+    config,
+    env,
+    providerAlias: provider,
+    model,
+    prompt: `${buildTableExtractionPrompt(page, renderArtifact.renderScale)}\n\nTask override:\n${prompt}`,
+    imageDataUrl,
+    runtimeApiKeys: request.providerApiKeys,
+  })
+  const parsed = parseJsonObject(raw) as { tables?: unknown[] }
+  const tables = normalizeTableItems(parsed?.tables)
+  const artifact: Omit<LocalPageTablesArtifact, "cacheStatus"> = {
+    documentId: record.documentId,
+    pageNumber: request.pageNumber,
+    renderScale: renderArtifact.renderScale,
+    sourceSizeBytes: record.sizeBytes,
+    sourceMtimeMs: record.mtimeMs,
+    provider,
+    model,
+    prompt,
+    imagePath: renderArtifact.imagePath,
+    pageArtifactPath: page.artifactPath,
+    renderArtifactPath: renderArtifact.artifactPath,
+    artifactPath,
+    generatedAt: new Date().toISOString(),
+    tables,
+  }
+  await writeJson(artifactPath, artifact)
+  return {
+    ...artifact,
+    cacheStatus: "fresh",
+  }
+}
+
+export const get_page_formulas_latex = async (
+  request: LocalPageFormulasRequest
+): Promise<LocalPageFormulasArtifact> => {
+  const env = resolveEnv(request.env)
+  const config = resolveConfig(request.config, env)
+  const { provider, model } = resolveAgentSelection(config, request)
+  const { record } = await indexDocumentInternal(request)
+  ensurePageNumber(record.pageCount, request.pageNumber)
+
+  const page = await get_page_content(request)
+  const renderArtifact = await ensureRenderArtifact(request)
+  const prompt = request.prompt?.trim() || "Extract displayed formulas from this PDF page as LaTeX math."
+  const artifactPath = buildStructuredArtifactPath(
+    record.artifactPaths.formulasDir,
+    request.pageNumber,
+    renderArtifact.renderScale,
+    provider,
+    model,
+    prompt
+  )
+
+  if (!request.forceRefresh && await fileExists(artifactPath)) {
+    const cached = await readJson<Omit<LocalPageFormulasArtifact, "cacheStatus"> & { cacheStatus?: unknown }>(artifactPath)
+    if (matchesSourceSnapshot(cached, record)) {
+      return {
+        ...cached,
+        cacheStatus: "reused",
+      }
+    }
+  }
+
+  const imageBytes = new Uint8Array(await readFile(renderArtifact.imagePath))
+  const imageDataUrl = toDataUrl(imageBytes, renderArtifact.mimeType)
+  const raw = await visionRecognize({
+    config,
+    env,
+    providerAlias: provider,
+    model,
+    prompt: `${buildFormulaExtractionPrompt(page, renderArtifact.renderScale)}\n\nTask override:\n${prompt}`,
+    imageDataUrl,
+    runtimeApiKeys: request.providerApiKeys,
+  })
+  const parsed = parseJsonObject(raw) as { formulas?: unknown[] }
+  const formulas = normalizeFormulaItems(parsed?.formulas)
+  const artifact: Omit<LocalPageFormulasArtifact, "cacheStatus"> = {
+    documentId: record.documentId,
+    pageNumber: request.pageNumber,
+    renderScale: renderArtifact.renderScale,
+    sourceSizeBytes: record.sizeBytes,
+    sourceMtimeMs: record.mtimeMs,
+    provider,
+    model,
+    prompt,
+    imagePath: renderArtifact.imagePath,
+    pageArtifactPath: page.artifactPath,
+    renderArtifactPath: renderArtifact.artifactPath,
+    artifactPath,
+    generatedAt: new Date().toISOString(),
+    formulas,
+  }
+  await writeJson(artifactPath, artifact)
+  return {
+    ...artifact,
+    cacheStatus: "fresh",
+  }
+}
 
 const getPageOcrMigrationOnly = async (request: LocalPageOcrRequest): Promise<LocalPageOcrArtifact> => {
   const env = resolveEnv(request.env)

--- a/tests/acceptance/local-technical-artifacts.acceptance.test.ts
+++ b/tests/acceptance/local-technical-artifacts.acceptance.test.ts
@@ -1,0 +1,258 @@
+import { createServer } from "node:http"
+import { access, mkdtemp, readFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it } from "vitest"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, "../..")
+const technicalPdf = path.join(rootDir, "fixtures", "input.pdf")
+const paperPdf = path.join(rootDir, "eval", "public-samples", "arxiv-attention-is-all-you-need.pdf")
+
+const ensureInput = async (pdfPath: string, hint: string): Promise<void> => {
+  try {
+    await access(pdfPath)
+  } catch {
+    throw new Error(`Missing acceptance PDF: ${pdfPath}. ${hint}`)
+  }
+}
+
+const buildTestConfig = (baseUrl: string) => ({
+  service: {
+    name: "echo-pdf",
+    publicBaseUrl: "https://echo-pdf.echofilesai.workers.dev",
+    fileGet: { cacheTtlSeconds: 300 },
+    maxPdfBytes: 10000000,
+    maxPagesPerRequest: 20,
+    defaultRenderScale: 2,
+    storage: {
+      maxFileBytes: 10000000,
+      maxTotalBytes: 52428800,
+      ttlHours: 24,
+      cleanupBatchSize: 50,
+    },
+  },
+  pdfium: {
+    wasmUrl: "https://cdn.jsdelivr.net/npm/@embedpdf/pdfium@2.7.0/dist/pdfium.wasm",
+  },
+  agent: {
+    defaultProvider: "openai",
+    defaultModel: "",
+    ocrPrompt: "unused",
+    tablePrompt: "unused",
+  },
+  providers: {
+    openai: {
+      type: "openai",
+      apiKeyEnv: "OPENAI_API_KEY",
+      baseUrl,
+      endpoints: {
+        chatCompletionsPath: "/chat/completions",
+        modelsPath: "/models",
+      },
+    },
+  },
+  mcp: {
+    serverName: "echo-pdf-mcp",
+    version: "0.1.0",
+    authHeader: "x-mcp-key",
+    authEnv: "ECHO_PDF_MCP_KEY",
+  },
+})
+
+const startStructuredArtifactsProvider = async (): Promise<{
+  baseUrl: string
+  close: () => Promise<void>
+}> => {
+  const server = createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/chat/completions") {
+      res.writeHead(404, { "content-type": "application/json" })
+      res.end(JSON.stringify({ error: "not found" }))
+      return
+    }
+
+    const chunks: Buffer[] = []
+    for await (const chunk of req) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+    const payload = JSON.parse(Buffer.concat(chunks).toString("utf-8")) as {
+      messages?: Array<{ content?: string | Array<{ type?: string; text?: string }> }>
+    }
+    const content = payload.messages?.[0]?.content
+    const prompt = typeof content === "string"
+      ? content
+      : Array.isArray(content)
+        ? content
+          .filter((part) => part?.type === "text" && typeof part.text === "string")
+          .map((part) => part.text ?? "")
+          .join("\n")
+        : ""
+
+    let body: unknown = { tables: [] }
+    if (prompt.includes("structured table artifacts")) {
+      body = prompt.includes("Maximum path lengths")
+        ? {
+            tables: [{
+              latexTabular: "\\begin{tabular}{lccc}\nLayer Type & Complexity per Layer & Sequential Operations & Maximum Path Length\\\\\nSelf-Attention & O(n^2 \\cdot d) & O(1) & O(1)\\\\\nRecurrent & O(n \\cdot d^2) & O(n) & O(n)\\\\\n\\end{tabular}",
+              caption: "Table 1",
+              evidenceText: "Maximum path lengths, per-layer complexity and minimum number of sequential operations",
+            }],
+          }
+        : { tables: [] }
+    } else if (prompt.includes("structured formula artifacts")) {
+      body = prompt.includes("Attention(Q, K, V ) = softmax")
+        ? {
+            formulas: [{
+              latexMath: "Attention(Q, K, V) = \\operatorname{softmax}\\left(\\frac{QK^T}{\\sqrt{d_k}}\\right)V",
+              label: "(1)",
+              evidenceText: "Attention(Q, K, V ) = softmax",
+            }],
+          }
+        : (prompt.includes("Differential Amplifier With Rail-to-Rail Output") || prompt.includes("rail-to-rail output signal is calculated"))
+          ? {
+              formulas: [{
+                latexMath: "U_{OUT} = \\left(1 + \\frac{R_2}{R_G}\\right) U_{IN} + U_{REF}",
+                label: "(4)",
+                evidenceText: "The rail-to-rail output signal is calculated using the following equation",
+              }],
+            }
+          : { formulas: [] }
+    }
+
+    res.writeHead(200, { "content-type": "application/json" })
+    res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(body) } }] }))
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => resolve())
+  })
+  const address = server.address()
+  if (!address || typeof address === "string") {
+    throw new Error("structured artifact provider did not bind a TCP port")
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+    },
+  }
+}
+
+const providerClosers: Array<() => Promise<void>> = []
+
+afterEach(async () => {
+  while (providerClosers.length > 0) {
+    const close = providerClosers.pop()
+    if (close) await close()
+  }
+})
+
+describe("technical latex artifacts on real PDFs", () => {
+  it("materializes LaTeX tabular artifacts from a real paper table page", async () => {
+    await ensureInput(
+      paperPdf,
+      "Run `npm run eval:fetch-public-samples -- --sample arxiv-attention-is-all-you-need` to prepare the canonical public sample."
+    )
+    const provider = await startStructuredArtifactsProvider()
+    providerClosers.push(provider.close)
+    const local = await import("@echofiles/echo-pdf/local")
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-accept-tables-"))
+    const config = buildTestConfig(provider.baseUrl)
+
+    const first = await local.get_page_tables_latex({
+      pdfPath: paperPdf,
+      workspaceDir,
+      pageNumber: 6,
+      config,
+      provider: "openai",
+      model: "structured-test-model",
+      env: { ...process.env, OPENAI_API_KEY: "test-key" },
+    }) as {
+      cacheStatus: "fresh" | "reused"
+      artifactPath: string
+      pageArtifactPath: string
+      renderArtifactPath: string
+      tables: Array<{ latexTabular: string; caption?: string; evidenceText?: string }>
+    }
+
+    const second = await local.get_page_tables_latex({
+      pdfPath: paperPdf,
+      workspaceDir,
+      pageNumber: 6,
+      config,
+      provider: "openai",
+      model: "structured-test-model",
+      env: { ...process.env, OPENAI_API_KEY: "test-key" },
+    }) as {
+      cacheStatus: "fresh" | "reused"
+      artifactPath: string
+    }
+
+    expect(first.cacheStatus).toBe("fresh")
+    expect(second.cacheStatus).toBe("reused")
+    expect(first.tables).toHaveLength(1)
+    expect(first.tables[0]?.latexTabular).toContain("\\begin{tabular}")
+    expect(first.tables[0]?.caption).toContain("Table 1")
+    expect(first.tables[0]?.evidenceText).toContain("Maximum path lengths")
+    expect(first.pageArtifactPath.endsWith(path.join("pages", "0006.json"))).toBe(true)
+    expect(first.renderArtifactPath.endsWith(path.join("renders", "0006.scale-2.json"))).toBe(true)
+    const stored = JSON.parse(await readFile(first.artifactPath, "utf-8")) as {
+      tables?: Array<{ latexTabular?: string }>
+    }
+    expect(stored.tables?.[0]?.latexTabular).toContain("\\begin{tabular}")
+  })
+
+  it("materializes LaTeX math artifacts from real paper and technical-document pages", async () => {
+    await ensureInput(
+      paperPdf,
+      "Run `npm run eval:fetch-public-samples -- --sample arxiv-attention-is-all-you-need` to prepare the canonical public sample."
+    )
+    await ensureInput(technicalPdf, "The committed technical fixture should exist in the repo.")
+    const provider = await startStructuredArtifactsProvider()
+    providerClosers.push(provider.close)
+    const local = await import("@echofiles/echo-pdf/local")
+    const config = buildTestConfig(provider.baseUrl)
+
+    const paper = await local.get_page_formulas_latex({
+      pdfPath: paperPdf,
+      workspaceDir: await mkdtemp(path.join(os.tmpdir(), "echo-pdf-accept-formula-paper-")),
+      pageNumber: 4,
+      config,
+      provider: "openai",
+      model: "structured-test-model",
+      env: { ...process.env, OPENAI_API_KEY: "test-key" },
+    }) as {
+      formulas: Array<{ latexMath: string; label?: string }>
+      pageArtifactPath: string
+    }
+    const technical = await local.get_page_formulas_latex({
+      pdfPath: technicalPdf,
+      workspaceDir: await mkdtemp(path.join(os.tmpdir(), "echo-pdf-accept-formula-tech-")),
+      pageNumber: 13,
+      config,
+      provider: "openai",
+      model: "structured-test-model",
+      env: { ...process.env, OPENAI_API_KEY: "test-key" },
+    }) as {
+      formulas: Array<{ latexMath: string; label?: string; evidenceText?: string }>
+      artifactPath: string
+      pageArtifactPath: string
+      renderArtifactPath: string
+    }
+
+    expect(paper.formulas[0]?.latexMath).toContain("\\operatorname{softmax}")
+    expect(paper.formulas[0]?.label).toBe("(1)")
+    expect(paper.pageArtifactPath.endsWith(path.join("pages", "0004.json"))).toBe(true)
+    expect(technical.formulas[0]?.latexMath).toContain("U_{OUT}")
+    expect(technical.formulas[0]?.label).toBe("(4)")
+    expect(technical.formulas[0]?.evidenceText).toContain("following equation")
+    expect(technical.pageArtifactPath.endsWith(path.join("pages", "0013.json"))).toBe(true)
+    expect(technical.renderArtifactPath.endsWith(path.join("renders", "0013.scale-2.json"))).toBe(true)
+    const stored = JSON.parse(await readFile(technical.artifactPath, "utf-8")) as {
+      formulas?: Array<{ latexMath?: string }>
+    }
+    expect(stored.formulas?.[0]?.latexMath).toContain("U_{OUT}")
+  })
+})

--- a/tests/integration/ts-nodenext-consumer.integration.test.ts
+++ b/tests/integration/ts-nodenext-consumer.integration.test.ts
@@ -39,6 +39,8 @@ describe("ts nodenext consumer smoke", () => {
         "local.get_document",
         "local.get_semantic_document_structure",
         "local.get_page_render",
+        "local.get_page_tables_latex",
+        "local.get_page_formulas_latex",
         "worker",
         "",
       ].join("\n"))


### PR DESCRIPTION
## Summary
- add local page-level structured artifact APIs for tables and formulas as LaTeX-first outputs
- materialize reusable `tables/` and `formulas/` workspace artifacts with page/render traceability
- add real-PDF acceptance coverage for table and formula artifacts and extend NodeNext consumer smoke to the new local exports

## Runtime Boundary
- local runtime only: [`/Users/huangjinfeng/workspace/echofiles/echo-pdf/src/local/index.ts`](/Users/huangjinfeng/workspace/echofiles/echo-pdf/src/local/index.ts)
- docs/contract only: [`/Users/huangjinfeng/workspace/echofiles/echo-pdf/README.md`](/Users/huangjinfeng/workspace/echofiles/echo-pdf/README.md), [`/Users/huangjinfeng/workspace/echofiles/echo-pdf/docs/WORKSPACE_CONTRACT.md`](/Users/huangjinfeng/workspace/echofiles/echo-pdf/docs/WORKSPACE_CONTRACT.md)
- no worker / MCP / SaaS changes
- no echo-datasheet changes

## Output Contract / Artifact Shape
New local APIs:
- `get_page_tables_latex(...)`
- `get_page_formulas_latex(...)`

New workspace artifacts:
- `tables/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`
- `formulas/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`

Table artifact contract:
- page-level JSON artifact
- includes source snapshot, provider/model, prompt, `pageArtifactPath`, `renderArtifactPath`, `imagePath`
- `tables[]` items carry `id`, `latexTabular`, optional `caption`, optional `evidenceText`

Formula artifact contract:
- page-level JSON artifact
- includes source snapshot, provider/model, prompt, `pageArtifactPath`, `renderArtifactPath`, `imagePath`
- `formulas[]` items carry `id`, `latexMath`, optional `label`, optional `evidenceText`

## Real PDF Validation
Used real PDFs in merge-gated acceptance tests:
- paper table + formula sample: [`/Users/huangjinfeng/workspace/echofiles/echo-pdf/eval/public-samples/arxiv-attention-is-all-you-need.pdf`](/Users/huangjinfeng/workspace/echofiles/echo-pdf/eval/public-samples/arxiv-attention-is-all-you-need.pdf)
  - page 6 table -> LaTeX `tabular`
  - page 4 displayed formula -> LaTeX math
- technical document formula sample: [`/Users/huangjinfeng/workspace/echofiles/echo-pdf/fixtures/input.pdf`](/Users/huangjinfeng/workspace/echofiles/echo-pdf/fixtures/input.pdf)
  - page 13 displayed equation -> LaTeX math

The acceptance tests use a local OpenAI-compatible endpoint so CI can verify the artifact path against real PDFs without depending on external provider credentials.

## Checks Run
- `bun run build`
- `test -f dist/local/index.js`
- `bun run typecheck`
- `bun run test:unit`
- `bun run test:acceptance`
- `bunx vitest run tests/integration/ts-nodenext-consumer.integration.test.ts`

## Intentionally Not Covered
- no CLI expansion beyond the existing six primitive surface
- no worker / MCP / SaaS surface changes
- no domain-specific datasheet logic
- multi-page table stitching and multi-line formula block reconstruction remain out of scope for this issue
