### PR TITLE
fix(local-runtime): restore built local CLI and pdfium parity

### DIFF
--- a/bin/echo-pdf.js
+++ b/bin/echo-pdf.js
@@ -189,6 +189,7 @@ const print = (data) => {
 }
 
 const LOCAL_DOCUMENT_DIST_ENTRY = new URL("../dist/local/index.js", import.meta.url)
+const LOCAL_DOCUMENT_DIST_PATH = fileURLToPath(LOCAL_DOCUMENT_DIST_ENTRY)
 const LOCAL_DOCUMENT_SOURCE_ENTRY = new URL("../src/local/index.ts", import.meta.url)
 const IS_BUN_RUNTIME = typeof process.versions?.bun === "string"
 const SHOULD_PREFER_SOURCE_DOCUMENT_API = process.env.ECHO_PDF_SOURCE_DEV === "1"
@@ -203,18 +204,13 @@ const loadLocalDocumentApi = async () => {
       "Use `npm run cli:dev -- <primitive> ...` only from a source checkout."
     )
   }
-  try {
-    return await import(LOCAL_DOCUMENT_DIST_ENTRY.href)
-  } catch (error) {
-    const code = error && typeof error === "object" ? error.code : ""
-    if (code === "ERR_MODULE_NOT_FOUND") {
-      throw new Error(
-        "Local primitive commands require built artifacts in a source checkout. " +
-        "Run `npm run build` first, use the internal `npm run cli:dev -- <primitive> ...` path in this repo, or install the published package."
-      )
-    }
-    throw error
+  if (!fs.existsSync(LOCAL_DOCUMENT_DIST_PATH)) {
+    throw new Error(
+      "Local primitive commands require built artifacts in a source checkout. " +
+      "Run `npm run build` first, use the internal `npm run cli:dev -- <primitive> ...` path in this repo, or install the published package."
+    )
   }
+  return import(LOCAL_DOCUMENT_DIST_ENTRY.href)
 }
 
 const LOCAL_PRIMITIVE_COMMANDS = ["document", "structure", "semantic", "page", "render"]
@@ -252,7 +248,6 @@ const readDocumentPrimitiveArgs = (command, subcommand, rest) => {
 }
 
 const runLocalPrimitiveCommand = async (command, subcommand, rest, flags) => {
-  const local = await loadLocalDocumentApi()
   const { primitive, pdfPath } = readDocumentPrimitiveArgs(command, subcommand, rest)
   const workspaceDir = typeof flags.workspace === "string" ? flags.workspace : undefined
   const forceRefresh = flags["force-refresh"] === true
@@ -263,17 +258,20 @@ const runLocalPrimitiveCommand = async (command, subcommand, rest, flags) => {
   }
 
   if (primitive === "document") {
+    const local = await loadLocalDocumentApi()
     print(await local.get_document({ pdfPath, workspaceDir, forceRefresh }))
     return
   }
 
   if (primitive === "structure") {
+    const local = await loadLocalDocumentApi()
     print(await local.get_document_structure({ pdfPath, workspaceDir, forceRefresh }))
     return
   }
 
   if (primitive === "semantic") {
     const semanticContext = resolveLocalSemanticContext(flags)
+    const local = await loadLocalDocumentApi()
     const data = await local.get_semantic_document_structure({
       pdfPath,
       workspaceDir,
@@ -297,11 +295,13 @@ const runLocalPrimitiveCommand = async (command, subcommand, rest, flags) => {
   }
 
   if (primitive === "page") {
+    const local = await loadLocalDocumentApi()
     print(await local.get_page_content({ pdfPath, workspaceDir, forceRefresh, pageNumber }))
     return
   }
 
   if (primitive === "render") {
+    const local = await loadLocalDocumentApi()
     print(await local.get_page_render({ pdfPath, workspaceDir, forceRefresh, pageNumber, renderScale }))
     return
   }

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -76,6 +76,7 @@ A clean consumer install should be able to:
 
 - install the published package artifact without patching package metadata
 - import each supported public entrypoint directly
+- execute the supported built local runtime path after install
 - typecheck NodeNext imports against the published declaration files
 
 The clean-consumer expectation is:
@@ -85,7 +86,8 @@ The clean-consumer expectation is:
    - `@echofiles/echo-pdf`
    - `@echofiles/echo-pdf/local`
 3. observe successful runtime import
-4. observe successful NodeNext typechecking
+4. execute the packaged local document/render runtime without patching private paths
+5. observe successful NodeNext typechecking
 
 This is the packaging-level guarantee for downstream adoption.
 
@@ -94,7 +96,7 @@ This is the packaging-level guarantee for downstream adoption.
 The repo already carries the corresponding smoke checks:
 
 - `tests/integration/npm-pack-import.integration.test.ts`
-  - verifies fresh import from a packed artifact
+  - verifies fresh import from a packed artifact and exercises the packaged local document/render runtime
 - `tests/integration/ts-nodenext-consumer.integration.test.ts`
   - verifies a fresh NodeNext consumer typechecks the public imports
 - `npm run test:import-smoke`

--- a/src/node/pdfium-local.ts
+++ b/src/node/pdfium-local.ts
@@ -3,6 +3,9 @@
 import { encode as encodePng } from "@cf-wasm/png"
 import { init } from "@embedpdf/pdfium"
 import type { WrappedPdfiumModule } from "@embedpdf/pdfium"
+import { readFile, stat } from "node:fs/promises"
+import { createRequire } from "node:module"
+import path from "node:path"
 import type { EchoPdfConfig } from "../pdf-types.js"
 
 let moduleInstance: WrappedPdfiumModule | null = null
@@ -22,13 +25,39 @@ const ensureWasmFunctionShim = (): void => {
   ) => fn
 }
 
-const readLocalPdfiumWasm = async (): Promise<ArrayBuffer> => {
-  const [{ readFile }, { createRequire }] = await Promise.all([
-    import("node:fs/promises"),
-    import("node:module"),
-  ])
+const resolveLocalPdfiumWasmPath = async (): Promise<string> => {
   const require = createRequire(import.meta.url)
-  const bytes = await readFile(require.resolve("@embedpdf/pdfium/pdfium.wasm"))
+  const candidates: string[] = []
+
+  try {
+    candidates.push(require.resolve("@embedpdf/pdfium/pdfium.wasm"))
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? error.code : ""
+    if (!["ERR_MODULE_NOT_FOUND", "MODULE_NOT_FOUND", "ERR_PACKAGE_PATH_NOT_EXPORTED"].includes(String(code))) {
+      throw error
+    }
+  }
+
+  const pdfiumEntry = require.resolve("@embedpdf/pdfium")
+  candidates.push(path.join(path.dirname(pdfiumEntry), "pdfium.wasm"))
+
+  for (const candidate of candidates) {
+    try {
+      await stat(candidate)
+      return candidate
+    } catch {
+      // Keep trying known package-local locations before surfacing a hard runtime error.
+    }
+  }
+
+  throw new Error(
+    "Failed to resolve the packaged PDFium WebAssembly binary for the local runtime."
+  )
+}
+
+const readLocalPdfiumWasm = async (): Promise<ArrayBuffer> => {
+  const wasmPath = await resolveLocalPdfiumWasmPath()
+  const bytes = await readFile(wasmPath)
   return new Uint8Array(bytes).slice().buffer
 }
 

--- a/tests/integration/local-document-cli.integration.test.ts
+++ b/tests/integration/local-document-cli.integration.test.ts
@@ -138,6 +138,16 @@ const runSourceCheckoutCliDev = async (repoDir: string, args: string[]): Promise
   return { stdout, stderr }
 }
 
+const createBuiltCheckout = async (): Promise<string> => {
+  const checkoutDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-built-checkout-"))
+  await cp(path.join(rootDir, "bin"), path.join(checkoutDir, "bin"), { recursive: true })
+  await cp(path.join(rootDir, "dist"), path.join(checkoutDir, "dist"), { recursive: true })
+  await cp(path.join(rootDir, "echo-pdf.config.json"), path.join(checkoutDir, "echo-pdf.config.json"))
+  await cp(path.join(rootDir, "package.json"), path.join(checkoutDir, "package.json"))
+  await symlink(path.join(rootDir, "node_modules"), path.join(checkoutDir, "node_modules"), "dir")
+  return checkoutDir
+}
+
 describe("local document CLI", () => {
   itWithNode20("reads a PDF through the zero-config local primitives", async () => {
     const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-"))
@@ -306,14 +316,27 @@ describe("local document CLI", () => {
     expect(stderr).toContain("echo-pdf model set --provider openai --model <model-id>")
   })
 
+  itWithNode20("preserves semantic setup guidance in built CLI mode before importing the local runtime", async () => {
+    const checkoutDir = await createBuiltCheckout()
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-home-built-no-model-"))
+    await writeFile(
+      path.join(checkoutDir, "dist", "local", "index.js"),
+      'import "./missing-local-runtime.js"\n',
+      "utf-8"
+    )
+
+    const { stderr } = await runCliFailure(checkoutDir, ["semantic", realFixturePdf, "--workspace", checkoutDir], {
+      HOME: homeDir,
+    })
+
+    expect(stderr).toContain('semantic requires a configured model for provider "openai"')
+    expect(stderr).toContain("echo-pdf model set --provider openai --model <model-id>")
+    expect(stderr).not.toContain("Local primitive commands require built artifacts")
+  })
+
   itWithNode20AndBun("supports the internal source-checkout cli:dev workflow even when dist artifacts exist", async () => {
-    const checkoutDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-source-"))
-    await cp(path.join(rootDir, "bin"), path.join(checkoutDir, "bin"), { recursive: true })
-    await cp(path.join(rootDir, "dist"), path.join(checkoutDir, "dist"), { recursive: true })
+    const checkoutDir = await createBuiltCheckout()
     await cp(path.join(rootDir, "src"), path.join(checkoutDir, "src"), { recursive: true })
-    await cp(path.join(rootDir, "echo-pdf.config.json"), path.join(checkoutDir, "echo-pdf.config.json"))
-    await cp(path.join(rootDir, "package.json"), path.join(checkoutDir, "package.json"))
-    await symlink(path.join(rootDir, "node_modules"), path.join(checkoutDir, "node_modules"), "dir")
     await writeFile(
       path.join(checkoutDir, "dist", "local", "index.js"),
       'throw new Error("dist local entry should not load in cli:dev");\n',

--- a/tests/integration/local-document.integration.test.ts
+++ b/tests/integration/local-document.integration.test.ts
@@ -1,14 +1,37 @@
 import { describe, expect, it } from "vitest"
-import { copyFile, mkdtemp, readFile, stat, writeFile } from "node:fs/promises"
+import { copyFile, cp, mkdtemp, readFile, stat, symlink, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = path.resolve(__dirname, "../..")
 const fixturePdf = path.join(rootDir, "fixtures", "smoke.pdf")
 
 describe("local document workflow", () => {
+  it("supports the built local runtime from a dist checkout", async () => {
+    const checkoutDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-built-local-"))
+    await cp(path.join(rootDir, "dist"), path.join(checkoutDir, "dist"), { recursive: true })
+    await copyFile(path.join(rootDir, "package.json"), path.join(checkoutDir, "package.json"))
+    await copyFile(path.join(rootDir, "echo-pdf.config.json"), path.join(checkoutDir, "echo-pdf.config.json"))
+    await symlink(path.join(rootDir, "node_modules"), path.join(checkoutDir, "node_modules"), "dir")
+
+    const local = await import(pathToFileURL(path.join(checkoutDir, "dist", "local", "index.js")).href)
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-built-local-ws-"))
+
+    const document = await local.get_document({ pdfPath: fixturePdf, workspaceDir }) as {
+      pageCount: number
+    }
+    const render = await local.get_page_render({ pdfPath: fixturePdf, workspaceDir, pageNumber: 1 }) as {
+      mimeType: string
+      imagePath: string
+    }
+
+    expect(document.pageCount).toBeGreaterThan(0)
+    expect(render.mimeType).toBe("image/png")
+    expect(render.imagePath.endsWith(".png")).toBe(true)
+  })
+
   it("indexes a PDF into inspectable local artifacts and reuses them", async () => {
     const local = await import("@echofiles/echo-pdf/local")
     const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-local-"))

--- a/tests/integration/local-semantic-structure.integration.test.ts
+++ b/tests/integration/local-semantic-structure.integration.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest"
-import { access, mkdtemp, readFile } from "node:fs/promises"
+import { access, copyFile, cp, mkdtemp, readFile, symlink } from "node:fs/promises"
 import { createServer } from "node:http"
 import os from "node:os"
 import path from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 import { writeSimplePdf } from "../helpers/write-simple-pdf.js"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -137,6 +137,32 @@ afterEach(async () => {
 })
 
 describe("local semantic document structure", () => {
+  it("supports the built semantic runtime from a dist checkout", async () => {
+    const checkoutDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-built-semantic-"))
+    await cp(path.join(rootDir, "dist"), path.join(checkoutDir, "dist"), { recursive: true })
+    await copyFile(path.join(rootDir, "package.json"), path.join(checkoutDir, "package.json"))
+    await copyFile(path.join(rootDir, "echo-pdf.config.json"), path.join(checkoutDir, "echo-pdf.config.json"))
+    await symlink(path.join(rootDir, "node_modules"), path.join(checkoutDir, "node_modules"), "dir")
+
+    const local = await import(pathToFileURL(path.join(checkoutDir, "dist", "local", "index.js")).href)
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-built-semantic-ws-"))
+    const fixtureDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-built-semantic-pdf-"))
+    const semanticPdf = path.join(fixtureDir, "built-semantic.pdf")
+
+    await writeSimplePdf(semanticPdf, [
+      ["Document Guide", "1 Overview", "Overview body text"],
+      ["2 Usage", "Usage body text"],
+    ])
+
+    const semantic = await local.get_semantic_document_structure({ pdfPath: semanticPdf, workspaceDir }) as {
+      detector: string
+      root: { children?: Array<{ title?: string }> }
+    }
+
+    expect(semantic.detector).toBe("heading-heuristic-v1")
+    expect(semantic.root.children?.map((node) => node.title)).toEqual(["1 Overview", "2 Usage"])
+  })
+
   it("adds a semantic structure artifact without changing the page index contract", async () => {
     const local = await import("@echofiles/echo-pdf/local")
     const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-semantic-"))

--- a/tests/integration/npm-pack-import.integration.test.ts
+++ b/tests/integration/npm-pack-import.integration.test.ts
@@ -9,6 +9,7 @@ import { promisify } from "node:util"
 const execFileAsync = promisify(execFile)
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = path.resolve(__dirname, "../..")
+const fixturePdf = path.join(rootDir, "fixtures", "smoke.pdf")
 
 const run = async (cmd: string, args: string[], cwd: string): Promise<string> => {
   const { stdout, stderr } = await execFileAsync(cmd, args, { cwd, env: process.env })
@@ -19,7 +20,7 @@ const run = async (cmd: string, args: string[], cwd: string): Promise<string> =>
 }
 
 describe("npm pack import smoke", () => {
-  it("imports package root/local from packed artifact", async () => {
+  it("imports package root/local and executes the packaged local runtime", async () => {
     const packJson = await run("npm", ["pack", "--json"], rootDir)
     const parsed = JSON.parse(packJson) as Array<{ filename?: string }>
     const filename = parsed[0]?.filename
@@ -38,9 +39,15 @@ describe("npm pack import smoke", () => {
         "if (typeof local.get_semantic_document_structure !== 'function') throw new Error('local.get_semantic_document_structure missing')",
         "if (typeof local.get_page_render !== 'function') throw new Error('local.get_page_render missing')",
         "if (typeof root.get_page_render !== 'function') throw new Error('root.get_page_render missing')",
+        "const pdfPath = process.argv[1]",
+        "const workspaceDir = process.argv[2]",
+        "const doc = await local.get_document({ pdfPath, workspaceDir })",
+        "const render = await local.get_page_render({ pdfPath, workspaceDir, pageNumber: 1 })",
+        "if (!doc.pageCount) throw new Error('pageCount missing')",
+        "if (render.mimeType !== 'image/png') throw new Error('render mimeType mismatch')",
         "console.log('ok')",
       ].join(";")
-      const output = await run("node", ["--input-type=module", "-e", code], tempDir)
+      const output = await run("node", ["--input-type=module", "-e", code, fixturePdf, path.join(tempDir, "workspace")], tempDir)
       expect(output.trim()).toContain("ok")
     } finally {
       await rm(tempDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- preserve built local CLI command semantics by validating primitive-specific inputs before importing the built local runtime, so command-level guidance is no longer masked by the generic built-artifact error path
- make the built local runtime resolve the packaged PDFium wasm through stable package-local paths, covering both the exported wasm subpath and a package-entry-adjacent fallback inside the installed package
- tighten local-only integration and packaging smoke coverage so built dist checkouts and packed consumer installs exercise the supported local runtime instead of only verifying importability

## Runtime Boundary
- Node local runtime only
- touched surfaces: built local CLI loading, built local PDFium wasm resolution, local integration coverage, packaging contract docs
- no service, worker, or MCP surfaces were added back

## Contract Surfaces Updated
- CLI runtime behavior in `bin/echo-pdf.js`
- built local PDFium runtime resolution in `src/node/pdfium-local.ts`
- local integration gates:
  - `tests/integration/local-document-cli.integration.test.ts`
  - `tests/integration/local-document.integration.test.ts`
  - `tests/integration/local-semantic-structure.integration.test.ts`
  - `tests/integration/npm-pack-import.integration.test.ts`
- packaging/runtime contract docs in `docs/PACKAGING.md`

## Checks Run
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `bunx vitest run tests/integration/local-document-cli.integration.test.ts tests/integration/local-document.integration.test.ts tests/integration/local-semantic-structure.integration.test.ts`
- [x] `bunx vitest run tests/integration/npm-pack-import.integration.test.ts`

## Intentionally Uncovered
- no new provider/model semantics beyond restoring the existing built local boundary
- no worker, service, MCP, or SaaS paths
- no broad docs rewrite outside the packaging/runtime contract text needed for this fix

Made with [Cursor](https://cursor.com)