### PR TITLE
chore(samples): clean up residual migrated sample artifacts

### DIFF
--- a/eval/examples/core-summary.example.json
+++ b/eval/examples/core-summary.example.json
@@ -79,8 +79,7 @@
         "structureJsonPath": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/semantic-structure.json",
         "pagesDir": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/pages",
-        "rendersDir": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/renders",
-        "ocrDir": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/ocr"
+        "rendersDir": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/renders"
       },
       "notes": "Representative public research paper for semantic structure comparisons."
     },
@@ -217,8 +216,7 @@
         "structureJsonPath": "eval/out/examples/core.workspace/documents/cb55555cc4fa90d7/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/core.workspace/documents/cb55555cc4fa90d7/semantic-structure.json",
         "pagesDir": "eval/out/examples/core.workspace/documents/cb55555cc4fa90d7/pages",
-        "rendersDir": "eval/out/examples/core.workspace/documents/cb55555cc4fa90d7/renders",
-        "ocrDir": "eval/out/examples/core.workspace/documents/cb55555cc4fa90d7/ocr"
+        "rendersDir": "eval/out/examples/core.workspace/documents/cb55555cc4fa90d7/renders"
       },
       "notes": "Public CISA framework for semantic structure comparisons on section-heavy guidance."
     },
@@ -355,8 +353,7 @@
         "structureJsonPath": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/semantic-structure.json",
         "pagesDir": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/pages",
-        "rendersDir": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/renders",
-        "ocrDir": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/ocr"
+        "rendersDir": "eval/out/examples/core.workspace/documents/44cefe56c9b5dcad/renders"
       },
       "notes": "Public research paper for OCR comparisons on dense multi-column text."
     },
@@ -454,8 +451,7 @@
         "structureJsonPath": "eval/out/examples/core.workspace/documents/0d2de462036fc194/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/core.workspace/documents/0d2de462036fc194/semantic-structure.json",
         "pagesDir": "eval/out/examples/core.workspace/documents/0d2de462036fc194/pages",
-        "rendersDir": "eval/out/examples/core.workspace/documents/0d2de462036fc194/renders",
-        "ocrDir": "eval/out/examples/core.workspace/documents/0d2de462036fc194/ocr"
+        "rendersDir": "eval/out/examples/core.workspace/documents/0d2de462036fc194/renders"
       },
       "notes": "Public long-form IRS guidance for OCR comparisons on dense cover-page text."
     },

--- a/eval/examples/known-bad-summary.example.json
+++ b/eval/examples/known-bad-summary.example.json
@@ -78,8 +78,7 @@
         "structureJsonPath": "eval/out/examples/known-bad.workspace/documents/0d2de462036fc194/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/known-bad.workspace/documents/0d2de462036fc194/semantic-structure.json",
         "pagesDir": "eval/out/examples/known-bad.workspace/documents/0d2de462036fc194/pages",
-        "rendersDir": "eval/out/examples/known-bad.workspace/documents/0d2de462036fc194/renders",
-        "ocrDir": "eval/out/examples/known-bad.workspace/documents/0d2de462036fc194/ocr"
+        "rendersDir": "eval/out/examples/known-bad.workspace/documents/0d2de462036fc194/renders"
       },
       "notes": "The heuristic path currently confuses TOC and running headers on a long public guide."
     },
@@ -160,8 +159,7 @@
         "structureJsonPath": "eval/out/examples/known-bad.workspace/documents/e8316eae43e9da70/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/known-bad.workspace/documents/e8316eae43e9da70/semantic-structure.json",
         "pagesDir": "eval/out/examples/known-bad.workspace/documents/e8316eae43e9da70/pages",
-        "rendersDir": "eval/out/examples/known-bad.workspace/documents/e8316eae43e9da70/renders",
-        "ocrDir": "eval/out/examples/known-bad.workspace/documents/e8316eae43e9da70/ocr"
+        "rendersDir": "eval/out/examples/known-bad.workspace/documents/e8316eae43e9da70/renders"
       },
       "notes": "The heuristic path currently overfits running headers and errata text on long NIST guidance."
     },

--- a/eval/examples/smoke-summary.example.json
+++ b/eval/examples/smoke-summary.example.json
@@ -73,8 +73,7 @@
         "structureJsonPath": "eval/out/examples/smoke.workspace/documents/0d2de462036fc194/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/smoke.workspace/documents/0d2de462036fc194/semantic-structure.json",
         "pagesDir": "eval/out/examples/smoke.workspace/documents/0d2de462036fc194/pages",
-        "rendersDir": "eval/out/examples/smoke.workspace/documents/0d2de462036fc194/renders",
-        "ocrDir": "eval/out/examples/smoke.workspace/documents/0d2de462036fc194/ocr"
+        "rendersDir": "eval/out/examples/smoke.workspace/documents/0d2de462036fc194/renders"
       },
       "notes": "Public long-form IRS guidance stays indexable as a dense operational sample."
     },
@@ -106,8 +105,7 @@
         "structureJsonPath": "eval/out/examples/smoke.workspace/documents/44cefe56c9b5dcad/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/smoke.workspace/documents/44cefe56c9b5dcad/semantic-structure.json",
         "pagesDir": "eval/out/examples/smoke.workspace/documents/44cefe56c9b5dcad/pages",
-        "rendersDir": "eval/out/examples/smoke.workspace/documents/44cefe56c9b5dcad/renders",
-        "ocrDir": "eval/out/examples/smoke.workspace/documents/44cefe56c9b5dcad/ocr"
+        "rendersDir": "eval/out/examples/smoke.workspace/documents/44cefe56c9b5dcad/renders"
       },
       "notes": "Public multi-column paper keeps obvious numbered sections in the heuristic path."
     },
@@ -172,8 +170,7 @@
         "structureJsonPath": "eval/out/examples/smoke.workspace/documents/cb55555cc4fa90d7/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/smoke.workspace/documents/cb55555cc4fa90d7/semantic-structure.json",
         "pagesDir": "eval/out/examples/smoke.workspace/documents/cb55555cc4fa90d7/pages",
-        "rendersDir": "eval/out/examples/smoke.workspace/documents/cb55555cc4fa90d7/renders",
-        "ocrDir": "eval/out/examples/smoke.workspace/documents/cb55555cc4fa90d7/ocr"
+        "rendersDir": "eval/out/examples/smoke.workspace/documents/cb55555cc4fa90d7/renders"
       },
       "notes": "Public CISA framework stays indexable as a large planning manual."
     },
@@ -205,8 +202,7 @@
         "structureJsonPath": "eval/out/examples/smoke.workspace/documents/e8316eae43e9da70/structure.json",
         "semanticStructureJsonPath": "eval/out/examples/smoke.workspace/documents/e8316eae43e9da70/semantic-structure.json",
         "pagesDir": "eval/out/examples/smoke.workspace/documents/e8316eae43e9da70/pages",
-        "rendersDir": "eval/out/examples/smoke.workspace/documents/e8316eae43e9da70/renders",
-        "ocrDir": "eval/out/examples/smoke.workspace/documents/e8316eae43e9da70/ocr"
+        "rendersDir": "eval/out/examples/smoke.workspace/documents/e8316eae43e9da70/renders"
       },
       "notes": "Public NIST security guidance stays indexable as a very long dense document."
     }

--- a/samples/index.js
+++ b/samples/index.js
@@ -1,3 +1,4 @@
+// Kept as plain JS because eval/*.mjs scripts import this file directly before any build step.
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 


### PR DESCRIPTION
## Summary
- remove stale `ocrDir` artifact paths from the checked-in eval example JSON so they no longer encode OCR as a first-class product surface
- delete the now-empty `fixtures/` directory from the working tree so contributors only see the shared `samples/` layout introduced in #88
- keep `samples/index.js` as plain JS but add an explicit comment documenting that `eval/*.mjs` imports it before any build step

## Scope
- no product behavior changes
- no sample ownership model changes beyond cleaning the residual migration gaps from #88
- no deleted surfaces were reintroduced

## Checks Run
- [x] `npm run typecheck`

## Intentionally Uncovered
- no runtime or product behavior changed, so broader test layers were not rerun for this cleanup-only PR

Made with [Cursor](https://cursor.com)