### PR TITLE
docs(site): clarify provider-required semantic setup

### DIFF
--- a/site/api/index.html
+++ b/site/api/index.html
@@ -35,7 +35,7 @@
             <tbody>
               <tr><td><code>get_document</code></td><td>document metadata</td><td><code>document.json</code></td><td>source snapshot and document root</td></tr>
               <tr><td><code>get_document_structure</code></td><td>stable page index</td><td><code>structure.json</code></td><td>iterate pages and locate page artifacts</td></tr>
-              <tr><td><code>get_semantic_document_structure</code></td><td>heading / section tree</td><td><code>semantic-structure.json</code></td><td>chapter navigation without mutating <code>pages[]</code></td></tr>
+              <tr><td><code>get_semantic_document_structure</code></td><td>heading / section tree</td><td><code>semantic-structure.json</code></td><td>chapter navigation without mutating <code>pages[]</code>; requires provider + model</td></tr>
               <tr><td><code>get_page_content</code></td><td>page text artifact</td><td><code>pages/&lt;page&gt;.json</code></td><td>page retrieval and semantic input</td></tr>
               <tr><td><code>get_page_render</code></td><td>render metadata</td><td><code>renders/&lt;page&gt;.json</code> + PNG</td><td>visual page reuse and VL input</td></tr>
             </tbody>
@@ -54,14 +54,23 @@
 } from "@echofiles/echo-pdf/local"</code></pre>
           </article>
           <article class="panel">
-            <h2>Runtime expectation</h2>
-            <ul>
-              <li>Node.js <code>&gt;=20</code></li>
-              <li>ESM import support</li>
-              <li>local-first Node/Bun runtime</li>
-              <li>package <code>exports</code> aware consumer</li>
-            </ul>
+            <h2>Provider-backed semantic call</h2>
+            <pre><code>const semantic = await get_semantic_document_structure({
+  pdfPath: "./sample.pdf",
+  provider: "openai",
+  model: "gpt-4.1-mini",
+})</code></pre>
           </article>
+        </section>
+        <section class="panel" style="margin-top:28px;">
+          <h2>Runtime expectation</h2>
+          <ul>
+            <li>Node.js <code>&gt;=20</code></li>
+            <li>ESM import support</li>
+            <li>local-first Node/Bun runtime</li>
+            <li>package <code>exports</code> aware consumer</li>
+            <li><code>get_semantic_document_structure</code> requires provider and model parameters or configured defaults</li>
+          </ul>
         </section>
         <section class="callout warn" style="margin-top:32px;">
           <h3>Not the place for broad tool sprawl.</h3>

--- a/site/cli/index.html
+++ b/site/cli/index.html
@@ -23,24 +23,30 @@
           <span class="eyebrow">CLI</span>
           <h1>One command surface, same VL-first core path.</h1>
           <p class="lead">
-            The local CLI centers the same mainline path as the package API: render, page understanding, semantic structure, and workspace artifacts.
+            The local CLI centers the same mainline path as the package API: document metadata, page access, render reuse, and provider-backed semantic structure.
           </p>
         </section>
 
         <section class="panel" style="margin-top:28px;">
-          <h2>Primary command mapping</h2>
+          <h2>Zero-config primitives</h2>
           <pre><code>echo-pdf document ./sample.pdf
 echo-pdf structure ./sample.pdf
-echo-pdf semantic ./sample.pdf
 echo-pdf page ./sample.pdf --page 1
 echo-pdf render ./sample.pdf --page 1</code></pre>
+        </section>
+        <section class="panel" style="margin-top:28px;">
+          <h2>Provider-required semantic setup</h2>
+          <pre><code>echo-pdf provider set --provider openai --api-key $OPENAI_API_KEY
+echo-pdf model set --provider openai --model gpt-4.1-mini
+echo-pdf semantic ./sample.pdf</code></pre>
         </section>
 
         <section class="two-col" style="margin-top:28px;">
           <article class="panel">
             <h2>Supported boundary</h2>
             <ul>
-              <li>the public local CLI surface is document / structure / semantic / page / render</li>
+              <li><code>document</code>, <code>structure</code>, <code>page</code>, and <code>render</code> work without provider configuration</li>
+              <li><code>semantic</code> requires a configured provider and model before it runs</li>
               <li>legacy <code>document ...</code> alias trees are not part of the supported docs path</li>
               <li>workspace-writing local runs stay the mainline workflow</li>
             </ul>

--- a/site/index.html
+++ b/site/index.html
@@ -82,15 +82,30 @@
         <p class="section-label">Agent-first happy path</p>
         <section class="example-grid">
           <div class="panel">
-            <h2>Minimal local run</h2>
+            <h2>Zero-config local run</h2>
             <pre><code>npm i -g @echofiles/echo-pdf
 
 echo-pdf document ./sample.pdf
 echo-pdf structure ./sample.pdf
-echo-pdf semantic ./sample.pdf
 echo-pdf page ./sample.pdf --page 1
 echo-pdf render ./sample.pdf --page 1</code></pre>
           </div>
+          <div class="panel">
+            <h2>Provider-backed semantic setup</h2>
+            <pre><code>echo-pdf provider set --provider openai --api-key $OPENAI_API_KEY
+echo-pdf model set --provider openai --model gpt-4.1-mini
+echo-pdf semantic ./sample.pdf</code></pre>
+          </div>
+        </section>
+
+        <section class="callout warn" style="margin-top:24px;">
+          <h3>Semantic is not zero-config.</h3>
+          <p>
+            <code>document</code>, <code>structure</code>, <code>page</code>, and <code>render</code> work without provider setup. <code>semantic</code> requires a configured local provider and model.
+          </p>
+        </section>
+
+        <section class="example-grid" style="margin-top:24px;">
           <div class="panel">
             <h2>Copyable output example</h2>
             <pre><code>{
@@ -126,7 +141,7 @@ echo-pdf render ./sample.pdf --page 1</code></pre>
               <li>downstream local tools can reuse the same workspace instead of reparsing PDFs</li>
               <li>cache reuse stays explicit through source snapshot and strategy metadata</li>
             </ul>
-          </div>
+          </article>
         </section>
 
         <p class="section-label">Information architecture</p>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -12,9 +12,14 @@ Primary surfaces:
 Core local primitives:
 - get_document
 - get_document_structure
-- get_semantic_document_structure
+- get_semantic_document_structure (requires provider and model)
 - get_page_content
 - get_page_render
+
+Provider-backed semantic CLI setup:
+- echo-pdf provider set --provider openai --api-key $OPENAI_API_KEY
+- echo-pdf model set --provider openai --model gpt-4.1-mini
+- echo-pdf semantic ./sample.pdf
 
 Key docs:
 - Overview: https://pdf.echofile.ai/


### PR DESCRIPTION
## Summary
- update the CLI docs page to separate zero-config primitives from provider-required semantic extraction and show the setup commands before the semantic example
- update the API docs page to note that `get_semantic_document_structure` requires provider/model input and add a minimal code example with explicit parameters
- update the overview and `llms.txt` so new readers immediately see that `document`/`structure`/`page`/`render` are zero-config while `semantic` requires provider setup

## Scope
- docs-site only
- no product runtime changes
- no hosted service or MCP references added

## Checks Run
- [x] `ReadLints` on the edited site files

## Intentionally Uncovered
- no code/runtime checks were run because this PR only updates static site content

Made with [Cursor](https://cursor.com)