### PR TITLE
feat(local): LaTeX-first table and formula page artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ What these commands map to:
 - `semantic` -> `get_semantic_document_structure`
 - `page` -> `get_page_content`
 - `render` -> `get_page_render`
+- `tables` -> `get_page_tables_latex`
+- `formulas` -> `get_page_formulas_latex`
 
 By default, `echo-pdf` writes reusable artifacts into a local workspace:
 
@@ -101,6 +103,10 @@ By default, `echo-pdf` writes reusable artifacts into a local workspace:
     renders/
       0001.scale-2.json
       0001.scale-2.png
+    tables/
+      0001.scale-2.provider-openai.model-gpt-4.1-mini.prompt-<hash>.json
+    formulas/
+      0001.scale-2.provider-openai.model-gpt-4.1-mini.prompt-<hash>.json
 ```
 
 These artifacts are meant to be inspected, cached, and reused by downstream local tools.
@@ -115,6 +121,8 @@ import {
   get_semantic_document_structure,
   get_page_content,
   get_page_render,
+  get_page_tables_latex,
+  get_page_formulas_latex,
 } from "@echofiles/echo-pdf/local"
 
 const document = await get_document({ pdfPath: "./sample.pdf" })
@@ -126,6 +134,8 @@ const semantic = await get_semantic_document_structure({
 })
 const page1 = await get_page_content({ pdfPath: "./sample.pdf", pageNumber: 1 })
 const render1 = await get_page_render({ pdfPath: "./sample.pdf", pageNumber: 1, scale: 2 })
+const tables = await get_page_tables_latex({ pdfPath: "./sample.pdf", pageNumber: 1, provider: "openai", model: "gpt-4.1-mini" })
+const formulas = await get_page_formulas_latex({ pdfPath: "./sample.pdf", pageNumber: 1, provider: "openai", model: "gpt-4.1-mini" })
 ```
 
 Notes:

--- a/bin/echo-pdf.js
+++ b/bin/echo-pdf.js
@@ -215,7 +215,7 @@ const loadLocalDocumentApi = async () => {
   return import(LOCAL_DOCUMENT_DIST_ENTRY.href)
 }
 
-const LOCAL_PRIMITIVE_COMMANDS = ["document", "structure", "semantic", "page", "render"]
+const LOCAL_PRIMITIVE_COMMANDS = ["document", "structure", "semantic", "page", "render", "tables", "formulas"]
 const REMOVED_DOCUMENT_ALIAS_TO_PRIMITIVE = {
   index: "document",
   get: "document",
@@ -302,6 +302,40 @@ const runLocalPrimitiveCommand = async (command, subcommand, rest, flags) => {
     return
   }
 
+  if (primitive === "tables") {
+    const semanticContext = resolveLocalSemanticContext(flags)
+    const local = await loadLocalDocumentApi()
+    print(await local.get_page_tables_latex({
+      pdfPath,
+      workspaceDir,
+      forceRefresh,
+      pageNumber,
+      renderScale,
+      provider: semanticContext.provider,
+      model: semanticContext.model,
+      providerApiKeys: semanticContext.providerApiKeys,
+      prompt: typeof flags.prompt === "string" ? flags.prompt : undefined,
+    }))
+    return
+  }
+
+  if (primitive === "formulas") {
+    const semanticContext = resolveLocalSemanticContext(flags)
+    const local = await loadLocalDocumentApi()
+    print(await local.get_page_formulas_latex({
+      pdfPath,
+      workspaceDir,
+      forceRefresh,
+      pageNumber,
+      renderScale,
+      provider: semanticContext.provider,
+      model: semanticContext.model,
+      providerApiKeys: semanticContext.providerApiKeys,
+      prompt: typeof flags.prompt === "string" ? flags.prompt : undefined,
+    }))
+    return
+  }
+
   throw new Error(`Unsupported local primitive command: ${primitive}`)
 }
 
@@ -313,6 +347,8 @@ const usage = () => {
   process.stdout.write(`  semantic <file.pdf> [--provider alias] [--model model] [--profile name] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  page <file.pdf> --page <N> [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  render <file.pdf> --page <N> [--scale N] [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  tables <file.pdf> --page <N> [--provider alias] [--model model] [--scale N] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  formulas <file.pdf> --page <N> [--provider alias] [--model model] [--scale N] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`\nLocal config commands:\n`)
   process.stdout.write(`  provider set --provider <${getProviderSetNames().join("|")}> --api-key <KEY> [--profile name]\n`)
   process.stdout.write(`  provider use --provider <${getProviderAliases().join("|")}> [--profile name]\n`)

--- a/docs/WORKSPACE_CONTRACT.md
+++ b/docs/WORKSPACE_CONTRACT.md
@@ -212,6 +212,58 @@ Downstream use:
 - visual page inspection
 - VL input reuse without rerendering the same page
 
+### `tables/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`
+
+Optional page-level table artifact (LaTeX-first).
+
+Required JSON fields:
+
+- `documentId`
+- `pageNumber`
+- `renderScale`
+- `sourceSizeBytes`
+- `sourceMtimeMs`
+- `provider`
+- `model`
+- `prompt`
+- `imagePath`
+- `pageArtifactPath`
+- `renderArtifactPath`
+- `artifactPath`
+- `generatedAt`
+- `tables` (array of `{ id, latexTabular, caption?, evidenceText? }`)
+
+Downstream use:
+
+- LaTeX tabular extraction from rendered page images
+- structured table reuse by downstream technical document agents
+
+### `formulas/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`
+
+Optional page-level formula artifact (LaTeX-first).
+
+Required JSON fields:
+
+- `documentId`
+- `pageNumber`
+- `renderScale`
+- `sourceSizeBytes`
+- `sourceMtimeMs`
+- `provider`
+- `model`
+- `prompt`
+- `imagePath`
+- `pageArtifactPath`
+- `renderArtifactPath`
+- `artifactPath`
+- `generatedAt`
+- `formulas` (array of `{ id, latexMath, label?, evidenceText? }`)
+
+Downstream use:
+
+- LaTeX math extraction from rendered page images
+- structured formula reuse by downstream technical document agents
+
 ## Cache Semantics
 
 ### Baseline indexing reuse
@@ -239,6 +291,7 @@ Additional reuse rules:
 
 - render artifacts are keyed by page number and render scale
 - semantic artifacts are keyed by source snapshot plus `strategyKey`
+- table and formula artifacts are keyed by page number, render scale, provider, model, and prompt hash
 
 ## Traceability Guarantees
 

--- a/echo-pdf.config.json
+++ b/echo-pdf.config.json
@@ -8,7 +8,8 @@
   "agent": {
     "defaultProvider": "openai",
     "defaultModel": "",
-    "tablePrompt": "Detect all tabular structures from this PDF page image. Output only valid LaTeX tabular environments, no explanations, no markdown fences."
+    "tablePrompt": "Detect all tabular structures from this PDF page image. Output only valid LaTeX tabular environments, no explanations, no markdown fences.",
+    "formulaPrompt": ""
   },
   "providers": {
     "openai": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@echofiles/echo-pdf",
   "description": "Local-first PDF document component core with CLI, workspace artifacts, and reusable page primitives.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "homepage": "https://pdf.echofile.ai/",
   "repository": {

--- a/site/api/index.html
+++ b/site/api/index.html
@@ -38,6 +38,8 @@
               <tr><td><code>get_semantic_document_structure</code></td><td>heading / section tree</td><td><code>semantic-structure.json</code></td><td>chapter navigation without mutating <code>pages[]</code>; requires provider + model and can target a local OpenAI-compatible server</td></tr>
               <tr><td><code>get_page_content</code></td><td>page text artifact</td><td><code>pages/&lt;page&gt;.json</code></td><td>page retrieval and semantic input</td></tr>
               <tr><td><code>get_page_render</code></td><td>render metadata</td><td><code>renders/&lt;page&gt;.json</code> + PNG</td><td>visual page reuse and VL input</td></tr>
+              <tr><td><code>get_page_tables_latex</code></td><td>LaTeX tabular artifacts</td><td><code>tables/&lt;page&gt;...json</code></td><td>structured table extraction; requires provider + model</td></tr>
+              <tr><td><code>get_page_formulas_latex</code></td><td>LaTeX math artifacts</td><td><code>formulas/&lt;page&gt;...json</code></td><td>displayed formula extraction; requires provider + model</td></tr>
             </tbody>
           </table>
         </section>
@@ -51,6 +53,8 @@
   get_semantic_document_structure,
   get_page_content,
   get_page_render,
+  get_page_tables_latex,
+  get_page_formulas_latex,
 } from "@echofiles/echo-pdf/local"</code></pre>
           </article>
           <article class="panel">

--- a/site/cli/index.html
+++ b/site/cli/index.html
@@ -44,7 +44,11 @@ echo-pdf semantic ./sample.pdf
 # Local OpenAI-compatible example (Ollama / LM Studio / vLLM / LocalAI)
 echo-pdf provider set --provider ollama --api-key ""
 echo-pdf model set --provider ollama --model llava:13b
-echo-pdf semantic ./sample.pdf --provider ollama</code></pre>
+echo-pdf semantic ./sample.pdf --provider ollama
+
+# LaTeX-first table and formula extraction (provider-required)
+echo-pdf tables ./sample.pdf --page 1
+echo-pdf formulas ./sample.pdf --page 1</code></pre>
         </section>
 
         <section class="two-col" style="margin-top:28px;">

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -15,6 +15,8 @@ Core local primitives:
 - get_semantic_document_structure (requires provider and model)
 - get_page_content
 - get_page_render
+- get_page_tables_latex (requires provider and model; outputs LaTeX tabular)
+- get_page_formulas_latex (requires provider and model; outputs LaTeX math)
 
 Provider-backed semantic CLI setup:
 - echo-pdf provider set --provider openai --api-key $OPENAI_API_KEY

--- a/src/local/formulas.ts
+++ b/src/local/formulas.ts
@@ -1,0 +1,105 @@
+/// <reference path="../node/compat.d.ts" />
+
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { toDataUrl } from "../file-utils.js"
+import { visionRecognize } from "../provider-client.js"
+import type { Env } from "../types.js"
+import { ensureRenderArtifact, indexDocumentInternal } from "./document.js"
+import {
+  buildStructuredArtifactPath,
+  ensurePageNumber,
+  fileExists,
+  matchesSourceSnapshot,
+  normalizeFormulaItems,
+  pageLabel,
+  parseJsonObject,
+  readJson,
+  resolveAgentSelection,
+  resolveConfig,
+  resolveEnv,
+  resolveRenderScale,
+  writeJson,
+} from "./shared.js"
+import type {
+  LocalPageFormulasArtifact,
+  LocalPageFormulasRequest,
+} from "./types.js"
+
+const DEFAULT_FORMULA_PROMPT =
+  "Detect all displayed mathematical formulas from this PDF page image. " +
+  "Return JSON only. Schema: " +
+  '{ "formulas": [{ "latexMath": "LaTeX math expression", "label": "optional equation label", "evidenceText": "optional" }] }. ' +
+  "Use LaTeX math notation. Do not include inline prose math or trivial single-symbol expressions. " +
+  "If no displayed formulas are found, return {\"formulas\":[]}."
+
+export const get_page_formulas_latex = async (
+  request: LocalPageFormulasRequest
+): Promise<LocalPageFormulasArtifact> => {
+  const env = resolveEnv(request.env)
+  const config = resolveConfig(request.config, env)
+  const { record } = await indexDocumentInternal(request)
+  ensurePageNumber(record.pageCount, request.pageNumber)
+
+  const { provider, model } = resolveAgentSelection(config, request)
+  const renderScale = resolveRenderScale(config, request.renderScale)
+  const prompt = typeof request.prompt === "string" && request.prompt.trim().length > 0
+    ? request.prompt.trim()
+    : DEFAULT_FORMULA_PROMPT
+
+  const formulasDir = path.join(record.artifactPaths.documentDir, "formulas")
+  const artifactPath = buildStructuredArtifactPath(formulasDir, request.pageNumber, renderScale, provider, model, prompt)
+
+  if (!request.forceRefresh && await fileExists(artifactPath)) {
+    const cached = await readJson<Omit<LocalPageFormulasArtifact, "cacheStatus"> & { cacheStatus?: unknown }>(artifactPath)
+    if (matchesSourceSnapshot(cached, record)) {
+      return { ...cached, cacheStatus: "reused" }
+    }
+  }
+
+  const renderArtifact = await ensureRenderArtifact({
+    pdfPath: request.pdfPath,
+    workspaceDir: request.workspaceDir,
+    forceRefresh: request.forceRefresh,
+    config,
+    pageNumber: request.pageNumber,
+    renderScale: request.renderScale,
+  })
+
+  const imageBytes = new Uint8Array(await readFile(renderArtifact.imagePath))
+  const imageDataUrl = toDataUrl(imageBytes, renderArtifact.mimeType)
+
+  const response = await visionRecognize({
+    config,
+    env,
+    providerAlias: provider,
+    model,
+    prompt,
+    imageDataUrl,
+    runtimeApiKeys: request.providerApiKeys,
+  })
+
+  const parsed = parseJsonObject(response) as { formulas?: unknown }
+  const formulas = normalizeFormulaItems(parsed?.formulas)
+
+  const pageArtifactPath = path.join(record.artifactPaths.pagesDir, `${pageLabel(request.pageNumber)}.json`)
+  const artifact: Omit<LocalPageFormulasArtifact, "cacheStatus"> = {
+    documentId: record.documentId,
+    pageNumber: request.pageNumber,
+    renderScale,
+    sourceSizeBytes: record.sizeBytes,
+    sourceMtimeMs: record.mtimeMs,
+    provider,
+    model,
+    prompt,
+    imagePath: renderArtifact.imagePath,
+    pageArtifactPath,
+    renderArtifactPath: renderArtifact.artifactPath,
+    artifactPath,
+    generatedAt: new Date().toISOString(),
+    formulas,
+  }
+
+  await writeJson(artifactPath, artifact)
+  return { ...artifact, cacheStatus: "fresh" }
+}

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -4,14 +4,22 @@ export type {
   LocalDocumentRequest,
   LocalDocumentStructure,
   LocalDocumentStructureNode,
+  LocalFormulaArtifactItem,
   LocalPageContent,
   LocalPageContentRequest,
+  LocalPageFormulasArtifact,
+  LocalPageFormulasRequest,
   LocalPageRenderArtifact,
   LocalPageRenderRequest,
+  LocalPageTablesArtifact,
+  LocalPageTablesRequest,
   LocalSemanticDocumentRequest,
   LocalSemanticDocumentStructure,
   LocalSemanticStructureNode,
+  LocalTableArtifactItem,
 } from "./types.js"
 
 export { get_document, get_document_structure, get_page_content, get_page_render } from "./document.js"
+export { get_page_formulas_latex } from "./formulas.js"
 export { get_semantic_document_structure } from "./semantic.js"
+export { get_page_tables_latex } from "./tables.js"

--- a/src/local/tables.ts
+++ b/src/local/tables.ts
@@ -1,0 +1,105 @@
+/// <reference path="../node/compat.d.ts" />
+
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { toDataUrl } from "../file-utils.js"
+import { visionRecognize } from "../provider-client.js"
+import type { Env } from "../types.js"
+import { ensureRenderArtifact, indexDocumentInternal } from "./document.js"
+import {
+  buildStructuredArtifactPath,
+  ensurePageNumber,
+  fileExists,
+  matchesSourceSnapshot,
+  normalizeTableItems,
+  pageLabel,
+  parseJsonObject,
+  readJson,
+  resolveAgentSelection,
+  resolveConfig,
+  resolveEnv,
+  resolveRenderScale,
+  writeJson,
+} from "./shared.js"
+import type {
+  LocalPageTablesArtifact,
+  LocalPageTablesRequest,
+} from "./types.js"
+
+const DEFAULT_TABLE_PROMPT =
+  "Detect all tabular structures from this PDF page image. " +
+  "Return JSON only. Schema: " +
+  '{ "tables": [{ "latexTabular": "\\\\begin{tabular}...\\\\end{tabular}", "caption": "optional", "evidenceText": "optional" }] }. ' +
+  "Each table must be a complete LaTeX tabular environment. " +
+  "If no tables are found, return {\"tables\":[]}."
+
+export const get_page_tables_latex = async (
+  request: LocalPageTablesRequest
+): Promise<LocalPageTablesArtifact> => {
+  const env = resolveEnv(request.env)
+  const config = resolveConfig(request.config, env)
+  const { record } = await indexDocumentInternal(request)
+  ensurePageNumber(record.pageCount, request.pageNumber)
+
+  const { provider, model } = resolveAgentSelection(config, request)
+  const renderScale = resolveRenderScale(config, request.renderScale)
+  const prompt = typeof request.prompt === "string" && request.prompt.trim().length > 0
+    ? request.prompt.trim()
+    : (config.agent.tablePrompt || DEFAULT_TABLE_PROMPT)
+
+  const tablesDir = path.join(record.artifactPaths.documentDir, "tables")
+  const artifactPath = buildStructuredArtifactPath(tablesDir, request.pageNumber, renderScale, provider, model, prompt)
+
+  if (!request.forceRefresh && await fileExists(artifactPath)) {
+    const cached = await readJson<Omit<LocalPageTablesArtifact, "cacheStatus"> & { cacheStatus?: unknown }>(artifactPath)
+    if (matchesSourceSnapshot(cached, record)) {
+      return { ...cached, cacheStatus: "reused" }
+    }
+  }
+
+  const renderArtifact = await ensureRenderArtifact({
+    pdfPath: request.pdfPath,
+    workspaceDir: request.workspaceDir,
+    forceRefresh: request.forceRefresh,
+    config,
+    pageNumber: request.pageNumber,
+    renderScale: request.renderScale,
+  })
+
+  const imageBytes = new Uint8Array(await readFile(renderArtifact.imagePath))
+  const imageDataUrl = toDataUrl(imageBytes, renderArtifact.mimeType)
+
+  const response = await visionRecognize({
+    config,
+    env,
+    providerAlias: provider,
+    model,
+    prompt,
+    imageDataUrl,
+    runtimeApiKeys: request.providerApiKeys,
+  })
+
+  const parsed = parseJsonObject(response) as { tables?: unknown }
+  const tables = normalizeTableItems(parsed?.tables)
+
+  const pageArtifactPath = path.join(record.artifactPaths.pagesDir, `${pageLabel(request.pageNumber)}.json`)
+  const artifact: Omit<LocalPageTablesArtifact, "cacheStatus"> = {
+    documentId: record.documentId,
+    pageNumber: request.pageNumber,
+    renderScale,
+    sourceSizeBytes: record.sizeBytes,
+    sourceMtimeMs: record.mtimeMs,
+    provider,
+    model,
+    prompt,
+    imagePath: renderArtifact.imagePath,
+    pageArtifactPath,
+    renderArtifactPath: renderArtifact.artifactPath,
+    artifactPath,
+    generatedAt: new Date().toISOString(),
+    tables,
+  }
+
+  await writeJson(artifactPath, artifact)
+  return { ...artifact, cacheStatus: "fresh" }
+}

--- a/src/pdf-types.ts
+++ b/src/pdf-types.ts
@@ -23,6 +23,7 @@ export interface EchoPdfConfig {
     readonly defaultProvider: string
     readonly defaultModel: string
     readonly tablePrompt: string
+    readonly formulaPrompt?: string
   }
   readonly providers: Record<string, EchoPdfProviderConfig>
 }

--- a/tests/integration/local-document-cli.integration.test.ts
+++ b/tests/integration/local-document-cli.integration.test.ts
@@ -109,6 +109,24 @@ const startSemanticCliTestProvider = async (options?: {
       return
     }
 
+    if (prompt.includes("tabular") || prompt.includes("table")) {
+      const response = {
+        tables: [{ latexTabular: "\\begin{tabular}{cc}\na & b\\\\\n\\end{tabular}", caption: "Test Table" }],
+      }
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(response) } }] }))
+      return
+    }
+
+    if (prompt.includes("formula") || prompt.includes("math")) {
+      const response = {
+        formulas: [{ latexMath: "E = mc^2", label: "eq:1" }],
+      }
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(response) } }] }))
+      return
+    }
+
     res.writeHead(400, { "content-type": "application/json" })
     res.end(JSON.stringify({ error: "unexpected prompt" }))
   })
@@ -353,6 +371,78 @@ describe("local document CLI", () => {
     expect(stderr.trim()).toBe("")
     expect(semantic.detector).toBe("agent-structured-v1")
     expect(semantic.root.children?.[0]?.title).toBe("1 Overview")
+  })
+
+  itWithNode20("extracts LaTeX tables from a page via the tables CLI command", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-home-tables-"))
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-tables-"))
+    const providerServer = await startSemanticCliTestProvider()
+    semanticCliTestServers.push(providerServer.close)
+    const env = {
+      HOME: homeDir,
+      ECHO_PDF_CONFIG_JSON: JSON.stringify({
+        service: { defaultRenderScale: 2 },
+        pdfium: { wasmUrl: "https://cdn.jsdelivr.net/npm/@embedpdf/pdfium@2.7.0/dist/pdfium.wasm" },
+        agent: { defaultProvider: "openai", defaultModel: "", tablePrompt: "detect tables" },
+        providers: {
+          openai: {
+            type: "openai",
+            apiKeyEnv: "OPENAI_API_KEY",
+            baseUrl: providerServer.baseUrl,
+            endpoints: { chatCompletionsPath: "/chat/completions", modelsPath: "/models" },
+          },
+        },
+      }),
+    }
+
+    await runCli(rootDir, ["provider", "set", "--provider", "openai", "--api-key", "test-key"], env)
+    await runCli(rootDir, ["model", "set", "--provider", "openai", "--model", "test-model"], env)
+
+    const { stdout } = await runCli(rootDir, ["tables", realFixturePdf, "--page", "1", "--workspace", workspaceDir], env)
+    const result = JSON.parse(stdout) as {
+      tables: Array<{ latexTabular: string; caption?: string }>
+      cacheStatus: string
+    }
+
+    expect(result.cacheStatus).toBe("fresh")
+    expect(result.tables.length).toBeGreaterThan(0)
+    expect(result.tables[0]?.latexTabular).toContain("\\begin{tabular}")
+  })
+
+  itWithNode20("extracts LaTeX formulas from a page via the formulas CLI command", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-home-formulas-"))
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-formulas-"))
+    const providerServer = await startSemanticCliTestProvider()
+    semanticCliTestServers.push(providerServer.close)
+    const env = {
+      HOME: homeDir,
+      ECHO_PDF_CONFIG_JSON: JSON.stringify({
+        service: { defaultRenderScale: 2 },
+        pdfium: { wasmUrl: "https://cdn.jsdelivr.net/npm/@embedpdf/pdfium@2.7.0/dist/pdfium.wasm" },
+        agent: { defaultProvider: "openai", defaultModel: "", tablePrompt: "unused" },
+        providers: {
+          openai: {
+            type: "openai",
+            apiKeyEnv: "OPENAI_API_KEY",
+            baseUrl: providerServer.baseUrl,
+            endpoints: { chatCompletionsPath: "/chat/completions", modelsPath: "/models" },
+          },
+        },
+      }),
+    }
+
+    await runCli(rootDir, ["provider", "set", "--provider", "openai", "--api-key", "test-key"], env)
+    await runCli(rootDir, ["model", "set", "--provider", "openai", "--model", "test-model"], env)
+
+    const { stdout } = await runCli(rootDir, ["formulas", realFixturePdf, "--page", "1", "--workspace", workspaceDir], env)
+    const result = JSON.parse(stdout) as {
+      formulas: Array<{ latexMath: string; label?: string }>
+      cacheStatus: string
+    }
+
+    expect(result.cacheStatus).toBe("fresh")
+    expect(result.formulas.length).toBeGreaterThan(0)
+    expect(result.formulas[0]?.latexMath).toBe("E = mc^2")
   })
 
   itWithNode20("fails early with a clear model error instead of silently falling back", async () => {

--- a/tests/integration/npm-pack-import.integration.test.ts
+++ b/tests/integration/npm-pack-import.integration.test.ts
@@ -40,6 +40,8 @@ describe("npm pack import smoke", () => {
         "if (typeof local.get_semantic_document_structure !== 'function') throw new Error('local.get_semantic_document_structure missing')",
         "if (typeof local.get_page_render !== 'function') throw new Error('local.get_page_render missing')",
         "if (typeof root.get_page_render !== 'function') throw new Error('root.get_page_render missing')",
+        "if (typeof local.get_page_tables_latex !== 'function') throw new Error('local.get_page_tables_latex missing')",
+        "if (typeof local.get_page_formulas_latex !== 'function') throw new Error('local.get_page_formulas_latex missing')",
         "const pdfPath = process.argv[1]",
         "const workspaceDir = process.argv[2]",
         "const doc = await local.get_document({ pdfPath, workspaceDir })",

--- a/tests/integration/ts-nodenext-consumer.integration.test.ts
+++ b/tests/integration/ts-nodenext-consumer.integration.test.ts
@@ -37,6 +37,8 @@ describe("ts nodenext consumer smoke", () => {
         "local.get_document",
         "local.get_semantic_document_structure",
         "local.get_page_render",
+        "local.get_page_tables_latex",
+        "local.get_page_formulas_latex",
         "",
       ].join("\n"))
       await writeFile(path.join(tempDir, "tsconfig.json"), JSON.stringify({

--- a/tests/unit/latex-normalize.test.ts
+++ b/tests/unit/latex-normalize.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { normalizeTableItems, normalizeFormulaItems } from "../../src/local/shared"
+
+describe("normalizeTableItems", () => {
+  it("keeps valid tabular environments and drops invalid ones", () => {
+    const items = normalizeTableItems([
+      { latexTabular: "\\begin{tabular}{cc}\na & b\\\\\n\\end{tabular}", caption: "Table 1" },
+      { latexTabular: "not a table" },
+      { latexTabular: "```latex\n\\begin{tabular}{c}\nvalue\\\\\n\\end{tabular}\n```" },
+    ])
+    expect(items).toHaveLength(2)
+    expect(items[0]?.id).toBe("table-1")
+    expect(items[0]?.latexTabular).toContain("\\begin{tabular}")
+    expect(items[0]?.caption).toBe("Table 1")
+    expect(items[1]?.id).toBe("table-3")
+  })
+
+  it("returns empty array for non-array input", () => {
+    expect(normalizeTableItems(null)).toEqual([])
+    expect(normalizeTableItems("bad")).toEqual([])
+  })
+})
+
+describe("normalizeFormulaItems", () => {
+  it("keeps non-empty latex math and drops empty ones", () => {
+    const items = normalizeFormulaItems([
+      { latexMath: "E = mc^2", label: "eq:1" },
+      { latexMath: "" },
+      { latexMath: "```latex\n\\frac{a}{b}\n```" },
+    ])
+    expect(items).toHaveLength(2)
+    expect(items[0]?.id).toBe("formula-1")
+    expect(items[0]?.latexMath).toBe("E = mc^2")
+    expect(items[0]?.label).toBe("eq:1")
+    expect(items[1]?.latexMath).toBe("\\frac{a}{b}")
+  })
+
+  it("returns empty array for non-array input", () => {
+    expect(normalizeFormulaItems(undefined)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- add two new local primitives: `get_page_tables_latex` and `get_page_formulas_latex`
- each produces page-level workspace artifacts with LaTeX tabular/math output, source snapshot traceability, and cache reuse semantics
- extend the CLI with `echo-pdf tables` and `echo-pdf formulas` commands
- update all published surfaces: package exports, types, CLI help, README, workspace contract, docs site, and llms.txt
- bump version to 0.8.0

## New Workspace Artifacts
- `tables/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`
- `formulas/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`

## Runtime Boundary
- Node local runtime only
- uses the existing render → vision model → parse pipeline
- requires provider + model (no heuristic fallback, per #91 design)

## Contract Surfaces Updated
- `src/local/tables.ts`, `src/local/formulas.ts` (new)
- `src/local/index.ts` exports
- `src/local/types.ts` (types already existed)
- `src/pdf-types.ts` (`formulaPrompt` field)
- `bin/echo-pdf.js` CLI commands and help
- `echo-pdf.config.json` (`formulaPrompt` field)
- `package.json` version 0.8.0
- `docs/WORKSPACE_CONTRACT.md`
- `README.md`
- `site/api/index.html`, `site/cli/index.html`, `site/llms.txt`
- `tests/unit/latex-normalize.test.ts`
- `tests/integration/local-document-cli.integration.test.ts`
- `tests/integration/npm-pack-import.integration.test.ts`
- `tests/integration/ts-nodenext-consumer.integration.test.ts`

## Checks Run
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run test:integration`

## Intentionally Uncovered
- no provider-backed acceptance tests for tables/formulas in this PR
- multi-page table stitching and multi-line formula block reconstruction remain out of scope

Made with [Cursor](https://cursor.com)