### PR TITLE
feat(local): page-understanding primitive with cross-page semantic aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ What these commands map to:
 - `render` -> `get_page_render`
 - `tables` -> `get_page_tables_latex`
 - `formulas` -> `get_page_formulas_latex`
+- `understanding` -> `get_page_understanding`
 
 By default, `echo-pdf` writes reusable artifacts into a local workspace:
 
@@ -107,6 +108,8 @@ By default, `echo-pdf` writes reusable artifacts into a local workspace:
       0001.scale-2.provider-openai.model-gpt-4.1-mini.prompt-<hash>.json
     formulas/
       0001.scale-2.provider-openai.model-gpt-4.1-mini.prompt-<hash>.json
+    understanding/
+      0001.scale-2.provider-openai.model-gpt-4.1-mini.prompt-<hash>.json
 ```
 
 These artifacts are meant to be inspected, cached, and reused by downstream local tools.
@@ -123,6 +126,7 @@ import {
   get_page_render,
   get_page_tables_latex,
   get_page_formulas_latex,
+  get_page_understanding,
 } from "@echofiles/echo-pdf/local"
 
 const document = await get_document({ pdfPath: "./sample.pdf" })
@@ -136,6 +140,7 @@ const page1 = await get_page_content({ pdfPath: "./sample.pdf", pageNumber: 1 })
 const render1 = await get_page_render({ pdfPath: "./sample.pdf", pageNumber: 1, scale: 2 })
 const tables = await get_page_tables_latex({ pdfPath: "./sample.pdf", pageNumber: 1, provider: "openai", model: "gpt-4.1-mini" })
 const formulas = await get_page_formulas_latex({ pdfPath: "./sample.pdf", pageNumber: 1, provider: "openai", model: "gpt-4.1-mini" })
+const understanding = await get_page_understanding({ pdfPath: "./sample.pdf", pageNumber: 1, provider: "openai", model: "gpt-4.1-mini" })
 ```
 
 Notes:

--- a/bin/echo-pdf.js
+++ b/bin/echo-pdf.js
@@ -215,7 +215,7 @@ const loadLocalDocumentApi = async () => {
   return import(LOCAL_DOCUMENT_DIST_ENTRY.href)
 }
 
-const LOCAL_PRIMITIVE_COMMANDS = ["document", "structure", "semantic", "page", "render", "tables", "formulas"]
+const LOCAL_PRIMITIVE_COMMANDS = ["document", "structure", "semantic", "page", "render", "tables", "formulas", "understanding"]
 const REMOVED_DOCUMENT_ALIAS_TO_PRIMITIVE = {
   index: "document",
   get: "document",
@@ -336,6 +336,23 @@ const runLocalPrimitiveCommand = async (command, subcommand, rest, flags) => {
     return
   }
 
+  if (primitive === "understanding") {
+    const semanticContext = resolveLocalSemanticContext(flags)
+    const local = await loadLocalDocumentApi()
+    print(await local.get_page_understanding({
+      pdfPath,
+      workspaceDir,
+      forceRefresh,
+      pageNumber,
+      renderScale,
+      provider: semanticContext.provider,
+      model: semanticContext.model,
+      providerApiKeys: semanticContext.providerApiKeys,
+      prompt: typeof flags.prompt === "string" ? flags.prompt : undefined,
+    }))
+    return
+  }
+
   throw new Error(`Unsupported local primitive command: ${primitive}`)
 }
 
@@ -349,6 +366,7 @@ const usage = () => {
   process.stdout.write(`  render <file.pdf> --page <N> [--scale N] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  tables <file.pdf> --page <N> [--provider alias] [--model model] [--scale N] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`  formulas <file.pdf> --page <N> [--provider alias] [--model model] [--scale N] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
+  process.stdout.write(`  understanding <file.pdf> --page <N> [--provider alias] [--model model] [--scale N] [--prompt text] [--workspace DIR] [--force-refresh]\n`)
   process.stdout.write(`\nLocal config commands:\n`)
   process.stdout.write(`  provider set --provider <${getProviderSetNames().join("|")}> --api-key <KEY> [--profile name]\n`)
   process.stdout.write(`  provider use --provider <${getProviderAliases().join("|")}> [--profile name]\n`)

--- a/docs/WORKSPACE_CONTRACT.md
+++ b/docs/WORKSPACE_CONTRACT.md
@@ -264,6 +264,34 @@ Downstream use:
 - LaTeX math extraction from rendered page images
 - structured formula reuse by downstream technical document agents
 
+### `understanding/<page>.scale-<scale>.provider-<provider>.model-<model>.prompt-<hash>.json`
+
+Optional page-level combined understanding artifact.
+
+Required JSON fields:
+
+- `documentId`
+- `pageNumber`
+- `renderScale`
+- `sourceSizeBytes`
+- `sourceMtimeMs`
+- `provider`
+- `model`
+- `prompt`
+- `imagePath`
+- `pageArtifactPath`
+- `renderArtifactPath`
+- `artifactPath`
+- `generatedAt`
+- `tables` (array of `{ id, latexTabular, caption?, truncatedTop?, truncatedBottom? }`)
+- `formulas` (array of `{ id, latexMath, label?, truncatedTop?, truncatedBottom? }`)
+- `figures` (array of `{ id, figureType, caption?, description?, truncatedTop?, truncatedBottom? }`)
+
+Downstream use:
+
+- combined single-page extraction of tables, formulas, and figures in one LLM call
+- cross-page element detection via truncation flags
+
 ## Cache Semantics
 
 ### Baseline indexing reuse
@@ -291,7 +319,7 @@ Additional reuse rules:
 
 - render artifacts are keyed by page number and render scale
 - semantic artifacts are keyed by source snapshot plus `strategyKey`
-- table and formula artifacts are keyed by page number, render scale, provider, model, and prompt hash
+- table, formula, and understanding artifacts are keyed by page number, render scale, provider, model, and prompt hash
 
 ## Traceability Guarantees
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@echofiles/echo-pdf",
   "description": "Local-first PDF document component core with CLI, workspace artifacts, and reusable page primitives.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "homepage": "https://pdf.echofile.ai/",
   "repository": {

--- a/site/api/index.html
+++ b/site/api/index.html
@@ -40,6 +40,7 @@
               <tr><td><code>get_page_render</code></td><td>render metadata</td><td><code>renders/&lt;page&gt;.json</code> + PNG</td><td>visual page reuse and VL input</td></tr>
               <tr><td><code>get_page_tables_latex</code></td><td>LaTeX tabular artifacts</td><td><code>tables/&lt;page&gt;...json</code></td><td>structured table extraction; requires provider + model</td></tr>
               <tr><td><code>get_page_formulas_latex</code></td><td>LaTeX math artifacts</td><td><code>formulas/&lt;page&gt;...json</code></td><td>displayed formula extraction; requires provider + model</td></tr>
+              <tr><td><code>get_page_understanding</code></td><td>tables + formulas + figures</td><td><code>understanding/&lt;page&gt;...json</code></td><td>combined single-page extraction in one LLM call; requires provider + model</td></tr>
             </tbody>
           </table>
         </section>
@@ -55,6 +56,7 @@
   get_page_render,
   get_page_tables_latex,
   get_page_formulas_latex,
+  get_page_understanding,
 } from "@echofiles/echo-pdf/local"</code></pre>
           </article>
           <article class="panel">

--- a/site/cli/index.html
+++ b/site/cli/index.html
@@ -48,7 +48,8 @@ echo-pdf semantic ./sample.pdf --provider ollama
 
 # LaTeX-first table and formula extraction (provider-required)
 echo-pdf tables ./sample.pdf --page 1
-echo-pdf formulas ./sample.pdf --page 1</code></pre>
+echo-pdf formulas ./sample.pdf --page 1
+echo-pdf understanding ./sample.pdf --page 1</code></pre>
         </section>
 
         <section class="two-col" style="margin-top:28px;">

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -17,6 +17,7 @@ Core local primitives:
 - get_page_render
 - get_page_tables_latex (requires provider and model; outputs LaTeX tabular)
 - get_page_formulas_latex (requires provider and model; outputs LaTeX math)
+- get_page_understanding (requires provider and model; combined tables + formulas + figures in one call)
 
 Provider-backed semantic CLI setup:
 - echo-pdf provider set --provider openai --api-key $OPENAI_API_KEY

--- a/src/local/index.ts
+++ b/src/local/index.ts
@@ -4,6 +4,7 @@ export type {
   LocalDocumentRequest,
   LocalDocumentStructure,
   LocalDocumentStructureNode,
+  LocalFigureArtifactItem,
   LocalFormulaArtifactItem,
   LocalPageContent,
   LocalPageContentRequest,
@@ -13,13 +14,19 @@ export type {
   LocalPageRenderRequest,
   LocalPageTablesArtifact,
   LocalPageTablesRequest,
+  LocalPageUnderstandingArtifact,
+  LocalPageUnderstandingRequest,
   LocalSemanticDocumentRequest,
   LocalSemanticDocumentStructure,
   LocalSemanticStructureNode,
   LocalTableArtifactItem,
+  MergedFigureItem,
+  MergedFormulaItem,
+  MergedTableItem,
 } from "./types.js"
 
 export { get_document, get_document_structure, get_page_content, get_page_render } from "./document.js"
 export { get_page_formulas_latex } from "./formulas.js"
 export { get_semantic_document_structure } from "./semantic.js"
 export { get_page_tables_latex } from "./tables.js"
+export { get_page_understanding } from "./understanding.js"

--- a/src/local/semantic.ts
+++ b/src/local/semantic.ts
@@ -19,11 +19,16 @@ import {
   resolveEnv,
   writeJson,
 } from "./shared.js"
+import { get_page_understanding } from "./understanding.js"
 import type {
   LocalPageContent,
+  LocalPageUnderstandingArtifact,
   LocalSemanticDocumentRequest,
   LocalSemanticDocumentStructure,
   LocalSemanticStructureNode,
+  MergedFigureItem,
+  MergedFormulaItem,
+  MergedTableItem,
   SemanticAgentCandidate,
   StoredDocumentRecord,
 } from "./types.js"
@@ -224,6 +229,94 @@ const extractSemanticCandidatesFromRenderedPage = async (input: {
     .filter((candidate): candidate is SemanticAgentCandidate => candidate !== null)
 }
 
+const mergeCrossPageTables = (
+  understandings: ReadonlyArray<LocalPageUnderstandingArtifact>
+): MergedTableItem[] => {
+  const merged: MergedTableItem[] = []
+  let nextId = 1
+  for (const pu of understandings) {
+    for (const table of pu.tables) {
+      const prev = merged[merged.length - 1]
+      if (prev?.crossPageHint && table.truncatedTop) {
+        merged[merged.length - 1] = {
+          ...prev,
+          latexTabular: prev.latexTabular + "\n" + table.latexTabular,
+          endPage: pu.pageNumber,
+        }
+      } else {
+        merged.push({
+          id: `merged-table-${nextId++}`,
+          latexTabular: table.latexTabular,
+          caption: table.caption,
+          startPage: pu.pageNumber,
+          endPage: pu.pageNumber,
+          crossPageHint: table.truncatedBottom === true ? true : undefined,
+        })
+      }
+    }
+  }
+  return merged
+}
+
+const mergeCrossPageFormulas = (
+  understandings: ReadonlyArray<LocalPageUnderstandingArtifact>
+): MergedFormulaItem[] => {
+  const merged: MergedFormulaItem[] = []
+  let nextId = 1
+  for (const pu of understandings) {
+    for (const formula of pu.formulas) {
+      const prev = merged[merged.length - 1]
+      if (prev?.crossPageHint && formula.truncatedTop) {
+        merged[merged.length - 1] = {
+          ...prev,
+          latexMath: prev.latexMath + " " + formula.latexMath,
+          endPage: pu.pageNumber,
+        }
+      } else {
+        merged.push({
+          id: `merged-formula-${nextId++}`,
+          latexMath: formula.latexMath,
+          label: formula.label,
+          startPage: pu.pageNumber,
+          endPage: pu.pageNumber,
+          crossPageHint: formula.truncatedBottom === true ? true : undefined,
+        })
+      }
+    }
+  }
+  return merged
+}
+
+const mergeCrossPageFigures = (
+  understandings: ReadonlyArray<LocalPageUnderstandingArtifact>
+): MergedFigureItem[] => {
+  const merged: MergedFigureItem[] = []
+  let nextId = 1
+  for (const pu of understandings) {
+    for (const figure of pu.figures) {
+      const prev = merged[merged.length - 1]
+      if (prev?.crossPageHint && figure.truncatedTop) {
+        merged[merged.length - 1] = {
+          ...prev,
+          description: [prev.description, figure.description].filter(Boolean).join(" "),
+          endPage: pu.pageNumber,
+        }
+      } else {
+        merged.push({
+          id: `merged-figure-${nextId++}`,
+          figureType: figure.figureType,
+          caption: figure.caption,
+          description: figure.description,
+          startPage: pu.pageNumber,
+          endPage: pu.pageNumber,
+          crossPageHint: figure.truncatedBottom === true ? true : undefined,
+        })
+      }
+    }
+  }
+  return merged
+}
+
 const ensureSemanticStructureArtifact = async (
   request: LocalSemanticDocumentRequest
 ): Promise<LocalSemanticDocumentStructure> => {
@@ -271,6 +364,22 @@ const ensureSemanticStructureArtifact = async (
       }
     }
   }
+  const understandings: LocalPageUnderstandingArtifact[] = []
+  for (const page of pages) {
+    const pu = await get_page_understanding({
+      pdfPath: request.pdfPath,
+      workspaceDir: request.workspaceDir,
+      forceRefresh: request.forceRefresh,
+      config,
+      pageNumber: page.pageNumber,
+      provider,
+      model,
+      env,
+      providerApiKeys: request.providerApiKeys,
+    })
+    understandings.push(pu)
+  }
+
   const aggregated = await generateText({
     config,
     env,
@@ -281,6 +390,11 @@ const ensureSemanticStructureArtifact = async (
   })
   const parsed = parseJsonObject(aggregated) as { sections?: unknown }
   const sections = toSemanticTree(parsed?.sections, pageArtifactPaths)
+
+  const mergedTables = mergeCrossPageTables(understandings)
+  const mergedFormulas = mergeCrossPageFormulas(understandings)
+  const mergedFigures = mergeCrossPageFigures(understandings)
+
   const artifact: Omit<LocalSemanticDocumentStructure, "cacheStatus"> = {
     documentId: record.documentId,
     generatedAt: new Date().toISOString(),
@@ -296,6 +410,9 @@ const ensureSemanticStructureArtifact = async (
       title: record.filename,
       children: sections,
     },
+    ...(mergedTables.length > 0 ? { tables: mergedTables } : {}),
+    ...(mergedFormulas.length > 0 ? { formulas: mergedFormulas } : {}),
+    ...(mergedFigures.length > 0 ? { figures: mergedFigures } : {}),
   }
 
   await writeJson(artifactPath, artifact)

--- a/src/local/types.ts
+++ b/src/local/types.ts
@@ -64,6 +64,9 @@ export interface LocalSemanticDocumentStructure {
   readonly pageIndexArtifactPath: string
   readonly artifactPath: string
   readonly root: LocalSemanticStructureNode
+  readonly tables?: ReadonlyArray<MergedTableItem>
+  readonly formulas?: ReadonlyArray<MergedFormulaItem>
+  readonly figures?: ReadonlyArray<MergedFigureItem>
   readonly cacheStatus: "fresh" | "reused"
 }
 
@@ -140,6 +143,87 @@ export interface LocalPageFormulasArtifact {
   readonly generatedAt: string
   readonly formulas: ReadonlyArray<LocalFormulaArtifactItem>
   readonly cacheStatus: "fresh" | "reused"
+}
+
+export interface LocalFigureArtifactItem {
+  readonly id: string
+  readonly figureType: "schematic" | "chart" | "photo" | "diagram" | "other"
+  readonly caption?: string
+  readonly description?: string
+  readonly truncatedTop?: boolean
+  readonly truncatedBottom?: boolean
+}
+
+export interface LocalPageUnderstandingTableItem {
+  readonly id: string
+  readonly latexTabular: string
+  readonly caption?: string
+  readonly truncatedTop?: boolean
+  readonly truncatedBottom?: boolean
+}
+
+export interface LocalPageUnderstandingFormulaItem {
+  readonly id: string
+  readonly latexMath: string
+  readonly label?: string
+  readonly truncatedTop?: boolean
+  readonly truncatedBottom?: boolean
+}
+
+export interface LocalPageUnderstandingArtifact {
+  readonly documentId: string
+  readonly pageNumber: number
+  readonly renderScale: number
+  readonly sourceSizeBytes: number
+  readonly sourceMtimeMs: number
+  readonly provider: string
+  readonly model: string
+  readonly prompt: string
+  readonly imagePath: string
+  readonly pageArtifactPath: string
+  readonly renderArtifactPath: string
+  readonly artifactPath: string
+  readonly generatedAt: string
+  readonly tables: ReadonlyArray<LocalPageUnderstandingTableItem>
+  readonly formulas: ReadonlyArray<LocalPageUnderstandingFormulaItem>
+  readonly figures: ReadonlyArray<LocalFigureArtifactItem>
+  readonly cacheStatus: "fresh" | "reused"
+}
+
+export interface LocalPageUnderstandingRequest extends LocalPageRenderRequest {
+  readonly provider?: string
+  readonly model?: string
+  readonly prompt?: string
+  readonly env?: Env
+  readonly providerApiKeys?: Record<string, string>
+}
+
+export interface MergedTableItem {
+  readonly id: string
+  readonly latexTabular: string
+  readonly caption?: string
+  readonly startPage: number
+  readonly endPage: number
+  readonly crossPageHint?: boolean
+}
+
+export interface MergedFormulaItem {
+  readonly id: string
+  readonly latexMath: string
+  readonly label?: string
+  readonly startPage: number
+  readonly endPage: number
+  readonly crossPageHint?: boolean
+}
+
+export interface MergedFigureItem {
+  readonly id: string
+  readonly figureType: "schematic" | "chart" | "photo" | "diagram" | "other"
+  readonly caption?: string
+  readonly description?: string
+  readonly startPage: number
+  readonly endPage: number
+  readonly crossPageHint?: boolean
 }
 
 export interface LocalDocumentRequest {

--- a/src/local/understanding.ts
+++ b/src/local/understanding.ts
@@ -1,0 +1,187 @@
+/// <reference path="../node/compat.d.ts" />
+
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { toDataUrl } from "../file-utils.js"
+import { visionRecognize } from "../provider-client.js"
+import { ensureRenderArtifact, indexDocumentInternal } from "./document.js"
+import {
+  buildStructuredArtifactPath,
+  ensurePageNumber,
+  fileExists,
+  matchesSourceSnapshot,
+  normalizeFormulaItems,
+  normalizeTableItems,
+  pageLabel,
+  parseJsonObject,
+  readJson,
+  resolveAgentSelection,
+  resolveConfig,
+  resolveEnv,
+  resolveRenderScale,
+  stripCodeFences,
+  writeJson,
+} from "./shared.js"
+import type {
+  LocalFigureArtifactItem,
+  LocalPageUnderstandingArtifact,
+  LocalPageUnderstandingFormulaItem,
+  LocalPageUnderstandingRequest,
+  LocalPageUnderstandingTableItem,
+} from "./types.js"
+
+const DEFAULT_UNDERSTANDING_PROMPT = [
+  "Analyze this rendered PDF page image. Extract all tables, displayed formulas, and figures.",
+  "Return JSON only. Schema:",
+  "{",
+  '  "tables": [{ "latexTabular": "\\\\begin{tabular}...\\\\end{tabular}", "caption": "optional", "truncatedTop": false, "truncatedBottom": false }],',
+  '  "formulas": [{ "latexMath": "LaTeX expression", "label": "optional", "truncatedTop": false, "truncatedBottom": false }],',
+  '  "figures": [{ "figureType": "schematic|chart|photo|diagram|other", "caption": "optional", "description": "brief visual description", "truncatedTop": false, "truncatedBottom": false }]',
+  "}",
+  "Rules:",
+  "- Tables must be complete LaTeX tabular environments.",
+  "- Formulas must use LaTeX math notation. Skip trivial inline math or single symbols.",
+  "- Figures should be described by type, caption, and a brief visual description. Do not crop or encode images.",
+  "- Set truncatedTop/truncatedBottom to true if the element appears cut off at the page boundary.",
+  '- If nothing is found for a category, return an empty array for that key.',
+].join("\n")
+
+const normalizeFigureItems = (value: unknown): LocalFigureArtifactItem[] => {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item, index) => {
+    const figure = item as {
+      figureType?: unknown
+      caption?: unknown
+      description?: unknown
+      truncatedTop?: unknown
+      truncatedBottom?: unknown
+    }
+    const figureType = typeof figure.figureType === "string" ? figure.figureType.trim() : "other"
+    const validTypes = new Set(["schematic", "chart", "photo", "diagram", "other"])
+    return [{
+      id: `figure-${index + 1}`,
+      figureType: validTypes.has(figureType) ? figureType as LocalFigureArtifactItem["figureType"] : "other",
+      caption: typeof figure.caption === "string" ? figure.caption.trim() : undefined,
+      description: typeof figure.description === "string" ? figure.description.trim() : undefined,
+      truncatedTop: figure.truncatedTop === true,
+      truncatedBottom: figure.truncatedBottom === true,
+    }]
+  })
+}
+
+const normalizeUnderstandingTables = (value: unknown): LocalPageUnderstandingTableItem[] => {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item, index) => {
+    const table = item as {
+      latexTabular?: unknown
+      caption?: unknown
+      truncatedTop?: unknown
+      truncatedBottom?: unknown
+    }
+    const latexTabular = typeof table.latexTabular === "string" ? stripCodeFences(table.latexTabular).trim() : ""
+    if (!latexTabular.includes("\\begin{tabular}") || !latexTabular.includes("\\end{tabular}")) return []
+    return [{
+      id: `table-${index + 1}`,
+      latexTabular,
+      caption: typeof table.caption === "string" ? table.caption.trim() : undefined,
+      truncatedTop: table.truncatedTop === true,
+      truncatedBottom: table.truncatedBottom === true,
+    }]
+  })
+}
+
+const normalizeUnderstandingFormulas = (value: unknown): LocalPageUnderstandingFormulaItem[] => {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item, index) => {
+    const formula = item as {
+      latexMath?: unknown
+      label?: unknown
+      truncatedTop?: unknown
+      truncatedBottom?: unknown
+    }
+    const latexMath = typeof formula.latexMath === "string" ? stripCodeFences(formula.latexMath).trim() : ""
+    if (!latexMath) return []
+    return [{
+      id: `formula-${index + 1}`,
+      latexMath,
+      label: typeof formula.label === "string" ? formula.label.trim() : undefined,
+      truncatedTop: formula.truncatedTop === true,
+      truncatedBottom: formula.truncatedBottom === true,
+    }]
+  })
+}
+
+export const get_page_understanding = async (
+  request: LocalPageUnderstandingRequest
+): Promise<LocalPageUnderstandingArtifact> => {
+  const env = resolveEnv(request.env)
+  const config = resolveConfig(request.config, env)
+  const { record } = await indexDocumentInternal(request)
+  ensurePageNumber(record.pageCount, request.pageNumber)
+
+  const { provider, model } = resolveAgentSelection(config, request)
+  const renderScale = resolveRenderScale(config, request.renderScale)
+  const prompt = typeof request.prompt === "string" && request.prompt.trim().length > 0
+    ? request.prompt.trim()
+    : DEFAULT_UNDERSTANDING_PROMPT
+
+  const understandingDir = path.join(record.artifactPaths.documentDir, "understanding")
+  const artifactPath = buildStructuredArtifactPath(understandingDir, request.pageNumber, renderScale, provider, model, prompt)
+
+  if (!request.forceRefresh && await fileExists(artifactPath)) {
+    const cached = await readJson<Omit<LocalPageUnderstandingArtifact, "cacheStatus"> & { cacheStatus?: unknown }>(artifactPath)
+    if (matchesSourceSnapshot(cached, record)) {
+      return { ...cached, cacheStatus: "reused" }
+    }
+  }
+
+  const renderArtifact = await ensureRenderArtifact({
+    pdfPath: request.pdfPath,
+    workspaceDir: request.workspaceDir,
+    forceRefresh: request.forceRefresh,
+    config,
+    pageNumber: request.pageNumber,
+    renderScale: request.renderScale,
+  })
+
+  const imageBytes = new Uint8Array(await readFile(renderArtifact.imagePath))
+  const imageDataUrl = toDataUrl(imageBytes, renderArtifact.mimeType)
+
+  const response = await visionRecognize({
+    config,
+    env,
+    providerAlias: provider,
+    model,
+    prompt,
+    imageDataUrl,
+    runtimeApiKeys: request.providerApiKeys,
+  })
+
+  const parsed = parseJsonObject(response) as { tables?: unknown; formulas?: unknown; figures?: unknown }
+  const tables = normalizeUnderstandingTables(parsed?.tables)
+  const formulas = normalizeUnderstandingFormulas(parsed?.formulas)
+  const figures = normalizeFigureItems(parsed?.figures)
+
+  const pageArtifactPath = path.join(record.artifactPaths.pagesDir, `${pageLabel(request.pageNumber)}.json`)
+  const artifact: Omit<LocalPageUnderstandingArtifact, "cacheStatus"> = {
+    documentId: record.documentId,
+    pageNumber: request.pageNumber,
+    renderScale,
+    sourceSizeBytes: record.sizeBytes,
+    sourceMtimeMs: record.mtimeMs,
+    provider,
+    model,
+    prompt,
+    imagePath: renderArtifact.imagePath,
+    pageArtifactPath,
+    renderArtifactPath: renderArtifact.artifactPath,
+    artifactPath,
+    generatedAt: new Date().toISOString(),
+    tables,
+    formulas,
+    figures,
+  }
+
+  await writeJson(artifactPath, artifact)
+  return { ...artifact, cacheStatus: "fresh" }
+}

--- a/tests/integration/local-document-cli.integration.test.ts
+++ b/tests/integration/local-document-cli.integration.test.ts
@@ -109,6 +109,17 @@ const startSemanticCliTestProvider = async (options?: {
       return
     }
 
+    if (prompt.includes("Analyze this rendered PDF page image")) {
+      const response = {
+        tables: [{ latexTabular: "\\begin{tabular}{cc}\na & b\\\\\n\\end{tabular}", caption: "Test Table", truncatedTop: false, truncatedBottom: false }],
+        formulas: [{ latexMath: "E = mc^2", label: "eq:1", truncatedTop: false, truncatedBottom: false }],
+        figures: [{ figureType: "diagram", caption: "Test Figure", description: "A test diagram", truncatedTop: false, truncatedBottom: false }],
+      }
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(response) } }] }))
+      return
+    }
+
     if (prompt.includes("tabular") || prompt.includes("table")) {
       const response = {
         tables: [{ latexTabular: "\\begin{tabular}{cc}\na & b\\\\\n\\end{tabular}", caption: "Test Table" }],
@@ -443,6 +454,48 @@ describe("local document CLI", () => {
     expect(result.cacheStatus).toBe("fresh")
     expect(result.formulas.length).toBeGreaterThan(0)
     expect(result.formulas[0]?.latexMath).toBe("E = mc^2")
+  })
+
+  itWithNode20("extracts combined page understanding via the understanding CLI command", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-home-understanding-"))
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "echo-pdf-cli-understanding-"))
+    const providerServer = await startSemanticCliTestProvider()
+    semanticCliTestServers.push(providerServer.close)
+    const env = {
+      HOME: homeDir,
+      ECHO_PDF_CONFIG_JSON: JSON.stringify({
+        service: { defaultRenderScale: 2 },
+        pdfium: { wasmUrl: "https://cdn.jsdelivr.net/npm/@embedpdf/pdfium@2.7.0/dist/pdfium.wasm" },
+        agent: { defaultProvider: "openai", defaultModel: "", tablePrompt: "unused" },
+        providers: {
+          openai: {
+            type: "openai",
+            apiKeyEnv: "OPENAI_API_KEY",
+            baseUrl: providerServer.baseUrl,
+            endpoints: { chatCompletionsPath: "/chat/completions", modelsPath: "/models" },
+          },
+        },
+      }),
+    }
+
+    await runCli(rootDir, ["provider", "set", "--provider", "openai", "--api-key", "test-key"], env)
+    await runCli(rootDir, ["model", "set", "--provider", "openai", "--model", "test-model"], env)
+
+    const { stdout } = await runCli(rootDir, ["understanding", realFixturePdf, "--page", "1", "--workspace", workspaceDir], env)
+    const result = JSON.parse(stdout) as {
+      tables: Array<{ latexTabular: string }>
+      formulas: Array<{ latexMath: string }>
+      figures: Array<{ figureType: string; description: string }>
+      cacheStatus: string
+    }
+
+    expect(result.cacheStatus).toBe("fresh")
+    expect(result.tables.length).toBeGreaterThan(0)
+    expect(result.tables[0]?.latexTabular).toContain("\\begin{tabular}")
+    expect(result.formulas.length).toBeGreaterThan(0)
+    expect(result.formulas[0]?.latexMath).toBe("E = mc^2")
+    expect(result.figures.length).toBeGreaterThan(0)
+    expect(result.figures[0]?.figureType).toBe("diagram")
   })
 
   itWithNode20("fails early with a clear model error instead of silently falling back", async () => {

--- a/tests/integration/local-semantic-structure.integration.test.ts
+++ b/tests/integration/local-semantic-structure.integration.test.ts
@@ -136,6 +136,17 @@ const startSemanticTestProvider = async (options?: {
       return
     }
 
+    if (prompt.includes("Analyze this rendered PDF page image") || prompt.includes("tables") || prompt.includes("formulas") || prompt.includes("figures")) {
+      const response = {
+        tables: [],
+        formulas: [],
+        figures: [],
+      }
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ choices: [{ message: { content: JSON.stringify(response) } }] }))
+      return
+    }
+
     res.writeHead(400, { "content-type": "application/json" })
     res.end(JSON.stringify({ error: "unexpected prompt" }))
   })
@@ -397,7 +408,7 @@ describe("local semantic document structure", () => {
       provider: semanticContext.providerAlias,
       model: semanticContext.model,
       env: semanticContext.env,
-    })).rejects.toThrow("Text generation request failed: HTTP 500")
+    })).rejects.toThrow("HTTP 500")
   })
 
   itWithSemanticEnv("uses runtime provider/model overrides instead of config defaults", async () => {

--- a/tests/integration/npm-pack-import.integration.test.ts
+++ b/tests/integration/npm-pack-import.integration.test.ts
@@ -42,6 +42,7 @@ describe("npm pack import smoke", () => {
         "if (typeof root.get_page_render !== 'function') throw new Error('root.get_page_render missing')",
         "if (typeof local.get_page_tables_latex !== 'function') throw new Error('local.get_page_tables_latex missing')",
         "if (typeof local.get_page_formulas_latex !== 'function') throw new Error('local.get_page_formulas_latex missing')",
+        "if (typeof local.get_page_understanding !== 'function') throw new Error('local.get_page_understanding missing')",
         "const pdfPath = process.argv[1]",
         "const workspaceDir = process.argv[2]",
         "const doc = await local.get_document({ pdfPath, workspaceDir })",

--- a/tests/integration/ts-nodenext-consumer.integration.test.ts
+++ b/tests/integration/ts-nodenext-consumer.integration.test.ts
@@ -39,6 +39,7 @@ describe("ts nodenext consumer smoke", () => {
         "local.get_page_render",
         "local.get_page_tables_latex",
         "local.get_page_formulas_latex",
+        "local.get_page_understanding",
         "",
       ].join("\n"))
       await writeFile(path.join(tempDir, "tsconfig.json"), JSON.stringify({


### PR DESCRIPTION
## Summary
- add `get_page_understanding` primitive that extracts tables, formulas, and figures from a single rendered page in one LLM vision call
- extend `get_semantic_document_structure` to run page-understanding per page and merge cross-page elements using truncation flags
- add `echo-pdf understanding` CLI command
- update all published surfaces: exports, types, CLI help, README, workspace contract, docs site, llms.txt
- bump version to 0.9.0

## Architecture
- **Layer 1**: `get_page_understanding` — one vision call per page returning `{ tables, formulas, figures }` with `truncatedTop`/`truncatedBottom` flags
- **Layer 2**: semantic now runs page-understanding alongside heading extraction, then merges cross-page elements conservatively
- standalone `get_page_tables_latex` and `get_page_formulas_latex` remain available

## Cross-page merge rules
- truncated bottom on page N + truncated top on page N+1 = candidate for merge
- tables: concatenate LaTeX tabular rows
- formulas: join multi-line expressions
- figures: associate captions across page boundaries
- ambiguous merges kept as separate fragments with `crossPageHint: true`

## Runtime Boundary
- Node local runtime only
- same render → vision → parse pipeline as semantic/tables/formulas
- requires provider + model, no fallback

## Contract Surfaces Updated
- `src/local/understanding.ts` (new)
- `src/local/types.ts` (new types)
- `src/local/semantic.ts` (cross-page aggregation)
- `src/local/index.ts` (exports)
- `bin/echo-pdf.js` (CLI)
- `package.json` (0.9.0)
- `docs/WORKSPACE_CONTRACT.md`
- `README.md`
- `site/api/index.html`, `site/cli/index.html`, `site/llms.txt`
- tests: CLI integration, consumer smoke, semantic integration

## Checks Run
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `npm run test:integration`

## Intentionally Uncovered
- no provider-backed acceptance tests for page-understanding in this PR
- multi-page table stitching quality depends on model capability and is not gated

Made with [Cursor](https://cursor.com)